### PR TITLE
Refactor task handling

### DIFF
--- a/hermes-five-macros/src/internals/mod.rs
+++ b/hermes-five-macros/src/internals/mod.rs
@@ -1,6 +1,6 @@
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{ItemFn, ReturnType, Signature, Stmt};
+use syn::{ItemFn, Signature};
 
 pub enum TokioMode {
     Main,
@@ -31,25 +31,7 @@ pub fn runtime_macro(item: TokenStream, tokio: TokioMode) -> TokenStream {
     };
 
     // Extract the block's statements
-    let mut stmts = block.stmts;
-
-    // Check if the function has an explicit return type
-    let has_return_type = match &sync_sig.output {
-        ReturnType::Default => false,
-        ReturnType::Type(_, ty) => {
-            !matches!(&**ty, syn::Type::Tuple(tuple) if tuple.elems.is_empty())
-        }
-    };
-
-    // Extract the last statement if it's an expression (potential return value)
-    let return_expr = if has_return_type {
-        match stmts.pop() {
-            Some(Stmt::Expr(expr, ..)) => Some(expr),
-            _ => None,
-        }
-    } else {
-        None
-    };
+    let stmts = block.stmts;
 
     // Define the #[test] attribute.
     let test_attr = match tokio {
@@ -57,55 +39,16 @@ pub fn runtime_macro(item: TokenStream, tokio: TokioMode) -> TokenStream {
         TokioMode::Test => quote! {#[test]},
     };
 
-    // Define the appropriate tokio runtime.
-    let tokio_runtime = match tokio {
-        TokioMode::Main => quote! {
-            let rt = #hermes_five::utils::tokio::runtime::Builder::new_multi_thread()
-                .worker_threads(4)
-                .enable_all()
-                .build()
-                .unwrap();
-        },
-        TokioMode::Test => quote! {
-            let rt = #hermes_five::utils::tokio::runtime::Runtime::new().unwrap();
-        },
-    };
-
-    // Generate the function body
-    let mut body = vec![quote! {
-        let receiver = #hermes_five::utils::task::init_task_channel();
-
-        // // Original code
-    }];
-
-    // Insert the original function body statements
-    // Check all "line-by-line" content within the body
-    body.extend(stmts.into_iter().map(|stmt| match stmt {
-        // In the case of an expression, we want to remove a null return "()" from the body
-        // since it will be added later as a return_expr.
-        Stmt::Expr(ref exp, _) => match exp {
-            syn::Expr::Tuple(tuple) if tuple.elems.is_empty() => quote!(),
-            _ => quote! { #stmt },
-        },
-        _ => quote! { #stmt },
-    }));
-
-    // Insert custom code after the original function body
-    body.push(quote! { receiver.wait().await; });
-
-    // Add the return expression if there is one
-    if let Some(return_stmt) = return_expr {
-        body.push(quote! { #return_stmt });
-    }
+    let is_test = matches!(tokio, TokioMode::Test);
 
     // Generate the expanded function
     quote! {
         #test_attr
         #(#attrs)*
         #vis #sync_sig {
-            #tokio_runtime
+            let rt = #hermes_five::utils::task::setup_rt(#is_test);
             rt.block_on(async {
-                #(#body)*
+                #(#stmts)*
             })
         }
     }
@@ -113,22 +56,12 @@ pub fn runtime_macro(item: TokenStream, tokio: TokioMode) -> TokenStream {
 
 #[cfg(test)]
 mod tests {
-    use proc_macro2::TokenStream;
     use quote::quote;
 
     use crate::internals::{runtime_macro, TokioMode};
 
-    fn before() -> TokenStream {
-        quote! {let receiver = ::hermes_five::utils::task::init_task_channel();}
-    }
-    fn after() -> TokenStream {
-        quote! { receiver.wait().await; }
-    }
     #[test]
     fn test_runtime_macro_result() {
-        let before = before();
-        let after = after();
-
         let input = quote! {
             async fn main() -> Result<(), Error> {
                 let x = 3;
@@ -138,20 +71,9 @@ mod tests {
 
         let control = quote! {
             fn main() -> Result<(), Error> {
-                let rt = ::hermes_five::utils::tokio::runtime::Builder::new_multi_thread()
-                .worker_threads(4)
-                .enable_all()
-                .build()
-                .unwrap();
+                let rt = ::hermes_five::utils::task::setup_rt(false);
                 rt.block_on(async {
-                    #before
-
-                    // Original code
                     let x = 3;
-                    // ---
-
-                    #after
-
                     Ok(())
                 })
             }
@@ -167,9 +89,6 @@ mod tests {
 
     #[test]
     fn test_runtime_macro_no_result() {
-        let before = before();
-        let after = after();
-
         let input = quote! {
             async fn main() {
                 let x = 3;
@@ -179,20 +98,10 @@ mod tests {
 
         let control = quote! {
             fn main() {
-                let rt = ::hermes_five::utils::tokio::runtime::Builder::new_multi_thread()
-                .worker_threads(4)
-                .enable_all()
-                .build()
-                .unwrap();
+                let rt = ::hermes_five::utils::task::setup_rt(false);
                 rt.block_on(async {
-                    #before
-
-                    // Original code
                     let x = 3;
                     blabla.await;
-                    // ---
-
-                    #after
                 })
             }
         };
@@ -207,9 +116,6 @@ mod tests {
 
     #[test]
     fn test_runtime_macro_explicit_void() {
-        let before = before();
-        let after = after();
-
         let input = quote! {
             async fn main() -> () {
                 let x = 3;
@@ -219,19 +125,10 @@ mod tests {
 
         let control = quote! {
             fn main() -> () {
-                let rt = ::hermes_five::utils::tokio::runtime::Builder::new_multi_thread()
-                .worker_threads(4)
-                .enable_all()
-                .build()
-                .unwrap();
+                let rt = ::hermes_five::utils::task::setup_rt(false);
                 rt.block_on(async {
-                    #before
-
-                    // Original code
                     let x = 3;
-                    // ---
-
-                    #after
+                    ()
                 })
             }
         };
@@ -246,9 +143,6 @@ mod tests {
 
     #[test]
     fn test_runtime_macro_test() {
-        let before = before();
-        let after = after();
-
         let input = quote! {
             async fn main() { }
         };
@@ -256,15 +150,8 @@ mod tests {
         let control = quote! {
             #[test]
             fn main() {
-                let rt = ::hermes_five::utils::tokio::runtime::Runtime::new().unwrap();
-                rt.block_on(async {
-                    #before
-
-                    // Original code
-                    // ---
-
-                    #after
-                })
+                let rt = ::hermes_five::utils::task::setup_rt(true);
+                rt.block_on(async { })
             }
         };
 

--- a/hermes-five-macros/src/internals/mod.rs
+++ b/hermes-five-macros/src/internals/mod.rs
@@ -73,7 +73,7 @@ pub fn runtime_macro(item: TokenStream, tokio: TokioMode) -> TokenStream {
 
     // Generate the function body
     let mut body = vec![quote! {
-        let mut receiver = #hermes_five::utils::task::init_task_channel().await;
+        let receiver = #hermes_five::utils::task::init_task_channel();
 
         // // Original code
     }];
@@ -91,29 +91,7 @@ pub fn runtime_macro(item: TokenStream, tokio: TokioMode) -> TokenStream {
     }));
 
     // Insert custom code after the original function body
-    body.push(quote! {
-        // ---
-
-        let receiver = &mut *receiver;
-
-        // Wait for all dynamically spawned tasks to complete.
-        while receiver.len() > 0 {
-            // We receive the task specific receiver.
-            if let Some(mut task_receiver) = receiver.recv().await {
-
-                // We receive the task result through that new receiver.
-                if let Ok(task_result) = task_receiver.await {
-                    match task_result {
-                        #hermes_five::utils::task::TaskResult::Ok => {},
-                        #hermes_five::utils::task::TaskResult::Err(err) => {
-                            #hermes_five::utils::log::error!("Task failed: {:?}", err.to_string());
-                            eprintln!("Task failed: {:?}", err.to_string());
-                        },
-                    }
-                }
-            }
-        }
-    });
+    body.push(quote! { receiver.wait().await; });
 
     // Add the return expression if there is one
     if let Some(return_stmt) = return_expr {
@@ -141,30 +119,10 @@ mod tests {
     use crate::internals::{runtime_macro, TokioMode};
 
     fn before() -> TokenStream {
-        quote! {let mut receiver = ::hermes_five::utils::task::init_task_channel().await;}
+        quote! {let receiver = ::hermes_five::utils::task::init_task_channel();}
     }
     fn after() -> TokenStream {
-        quote! {
-            let receiver = &mut *receiver;
-
-            // Wait for all dynamically spawned tasks to complete.
-            while receiver.len() > 0 {
-                // We receive the task specific receiver.
-                if let Some(mut task_receiver) = receiver.recv().await {
-
-                    // We receive the task result through that new receiver.
-                    if let Ok(task_result) = task_receiver.await {
-                        match task_result {
-                            ::hermes_five::utils::task::TaskResult::Ok => {},
-                            ::hermes_five::utils::task::TaskResult::Err(err) => {
-                                ::hermes_five::utils::log::error!("Task failed: {:?}", err.to_string());
-                                eprintln!("Task failed: {:?}", err.to_string());
-                            },
-                        }
-                    }
-                }
-            }
-        }
+        quote! { receiver.wait().await; }
     }
     #[test]
     fn test_runtime_macro_result() {

--- a/hermes-five-macros/src/internals/mod.rs
+++ b/hermes-five-macros/src/internals/mod.rs
@@ -73,7 +73,7 @@ pub fn runtime_macro(item: TokenStream, tokio: TokioMode) -> TokenStream {
 
     // Generate the function body
     let mut body = vec![quote! {
-        #hermes_five::utils::task::init_task_channel().await;
+        let mut receiver = #hermes_five::utils::task::init_task_channel().await;
 
         // // Original code
     }];
@@ -94,9 +94,7 @@ pub fn runtime_macro(item: TokenStream, tokio: TokioMode) -> TokenStream {
     body.push(quote! {
         // ---
 
-        let cell = #hermes_five::utils::task::RUNTIME_RX.get().ok_or(#hermes_five::errors::RuntimeError).unwrap();
-        let mut lock = cell.lock();
-        let receiver = lock.as_mut().ok_or(#hermes_five::errors::RuntimeError).unwrap();
+        let receiver = &mut *receiver;
 
         // Wait for all dynamically spawned tasks to complete.
         while receiver.len() > 0 {
@@ -104,7 +102,7 @@ pub fn runtime_macro(item: TokenStream, tokio: TokioMode) -> TokenStream {
             if let Some(mut task_receiver) = receiver.recv().await {
 
                 // We receive the task result through that new receiver.
-                if let Some(task_result) = task_receiver.recv().await {
+                if let Ok(task_result) = task_receiver.await {
                     match task_result {
                         #hermes_five::utils::task::TaskResult::Ok => {},
                         #hermes_five::utils::task::TaskResult::Err(err) => {
@@ -143,13 +141,11 @@ mod tests {
     use crate::internals::{runtime_macro, TokioMode};
 
     fn before() -> TokenStream {
-        quote! {::hermes_five::utils::task::init_task_channel().await;}
+        quote! {let mut receiver = ::hermes_five::utils::task::init_task_channel().await;}
     }
     fn after() -> TokenStream {
         quote! {
-            let cell = ::hermes_five::utils::task::RUNTIME_RX.get().ok_or(::hermes_five::errors::RuntimeError).unwrap();
-            let mut lock = cell.lock();
-            let receiver = lock.as_mut().ok_or(::hermes_five::errors::RuntimeError).unwrap();
+            let receiver = &mut *receiver;
 
             // Wait for all dynamically spawned tasks to complete.
             while receiver.len() > 0 {
@@ -157,7 +153,7 @@ mod tests {
                 if let Some(mut task_receiver) = receiver.recv().await {
 
                     // We receive the task result through that new receiver.
-                    if let Some(task_result) = task_receiver.recv().await {
+                    if let Ok(task_result) = task_receiver.await {
                         match task_result {
                             ::hermes_five::utils::task::TaskResult::Ok => {},
                             ::hermes_five::utils::task::TaskResult::Err(err) => {

--- a/hermes-five/examples/led/brightness.rs
+++ b/hermes-five/examples/led/brightness.rs
@@ -1,6 +1,5 @@
 use hermes_five::devices::Led;
 use hermes_five::hardware::{Board, BoardEvent};
-use hermes_five::io::IO;
 // /!\ Use of brightness requires a PWM compatible pin.
 // Consult your board schematics to know which ones are compatible.
 

--- a/hermes-five/src/utils/task.rs
+++ b/hermes-five/src/utils/task.rs
@@ -1,9 +1,10 @@
 //! Defines Hermes-Five Runtime task runner.
-use std::future::Future;
 use std::sync::OnceLock;
+use std::task::Poll;
+use std::{future::Future, task::ready};
 
-use parking_lot::{Mutex, MutexGuard};
-use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
+use futures::{stream::FuturesUnordered, StreamExt};
+use parking_lot::RwLock;
 use tokio::sync::oneshot;
 use tokio::task;
 use tokio::task::JoinHandle;
@@ -21,12 +22,7 @@ pub enum TaskResult {
 /// Represents an arc protected handler for a task.
 pub type TaskHandler = JoinHandle<Result<(), Error>>;
 
-/// Globally accessible runtime transmitter(TX)/receiver(RX) (not initialised yet)
-static RUNTIME_TX: OnceLock<Mutex<UnboundedSender<oneshot::Receiver<TaskResult>>>> =
-    OnceLock::new();
-
-#[doc(hidden)]
-static RUNTIME_RX: OnceLock<Mutex<UnboundedReceiver<oneshot::Receiver<TaskResult>>>> =
+static RUNTIME_TASKS: OnceLock<RwLock<FuturesUnordered<oneshot::Receiver<TaskResult>>>> =
     OnceLock::new();
 
 impl From<Result<(), Error>> for TaskResult {
@@ -44,21 +40,34 @@ impl From<()> for TaskResult {
     }
 }
 
-pub async fn init_task_channel(
-) -> MutexGuard<'static, UnboundedReceiver<oneshot::Receiver<TaskResult>>> {
-    // If no receiver is configured, create a new one (with associated sender).
-    let rx = RUNTIME_RX.get_or_init(|| {
-        // Arbitrary limit to 100 simultaneous tasks.
-        let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<oneshot::Receiver<TaskResult>>();
+pub fn init_task_channel() -> TaskQueueConsumer {
+    TaskQueueConsumer {
+        queue: RUNTIME_TASKS.get_or_init(|| RwLock::new(FuturesUnordered::new())),
+    }
+}
 
-        // Set the runtime sender.
-        RUNTIME_TX.get_or_init(|| Mutex::new(tx));
+pub struct TaskQueueConsumer {
+    queue: &'static RwLock<FuturesUnordered<oneshot::Receiver<TaskResult>>>,
+}
 
-        // Set the runtime receiver.
-        Mutex::new(rx)
-    });
-
-    rx.lock()
+impl TaskQueueConsumer {
+    pub async fn wait(self) {
+        futures::stream::poll_fn(|cx| self.queue.write().poll_next_unpin(cx))
+            .for_each(|task_result| async {
+                match task_result {
+                    Ok(TaskResult::Ok) => {}
+                    Err(_) => {
+                        log::error!("Task aborted");
+                        eprintln!("Task aborted");
+                    }
+                    Ok(TaskResult::Err(err)) => {
+                        log::error!("Task failed: {:?}", err.to_string());
+                        eprintln!("Task failed: {:?}", err.to_string());
+                    }
+                }
+            })
+            .await
+    }
 }
 
 /// Runs a given future as a Tokio task while ensuring the main function (marked by `#[hermes_five::runtime]`)
@@ -98,21 +107,15 @@ where
     let handler = task::spawn(async move {
         // ...to send the result of the future through that channel.
         let result = future.await.into();
-        task_tx.send(result).map_err(|_result: TaskResult| UnknownError {
-            info: "task receiver was closed".to_string(),
-        })?;
-        Ok(())
+        task_tx
+            .send(result)
+            .map_err(|_result: TaskResult| UnknownError {
+                info: "task receiver was closed".to_string(),
+            })
     });
 
-    // --
-    // Send the receiver(rx) side of the task-channel to the runtime.
-
-    let cell = RUNTIME_TX.get().ok_or(RuntimeError)?;
-    let runtime_tx = cell.lock();
-
-    runtime_tx.send(task_rx).map_err(|err| UnknownError {
-        info: err.to_string(),
-    })?;
+    let tasks = RUNTIME_TASKS.get().ok_or(RuntimeError)?;
+    tasks.read().push(task_rx);
 
     Ok(handler)
 }

--- a/hermes-five/src/utils/task.rs
+++ b/hermes-five/src/utils/task.rs
@@ -1,9 +1,10 @@
 //! Defines Hermes-Five Runtime task runner.
 use std::future::Future;
+use std::sync::OnceLock;
 
-use parking_lot::Mutex;
+use parking_lot::{Mutex, MutexGuard};
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
-use tokio::sync::OnceCell;
+use tokio::sync::oneshot;
 use tokio::task;
 use tokio::task::JoinHandle;
 
@@ -21,10 +22,12 @@ pub enum TaskResult {
 pub type TaskHandler = JoinHandle<Result<(), Error>>;
 
 /// Globally accessible runtime transmitter(TX)/receiver(RX) (not initialised yet)
-pub static RUNTIME_TX: OnceCell<Mutex<Option<UnboundedSender<UnboundedReceiver<TaskResult>>>>> =
-    OnceCell::const_new();
-pub static RUNTIME_RX: OnceCell<Mutex<Option<UnboundedReceiver<UnboundedReceiver<TaskResult>>>>> =
-    OnceCell::const_new();
+static RUNTIME_TX: OnceLock<Mutex<UnboundedSender<oneshot::Receiver<TaskResult>>>> =
+    OnceLock::new();
+
+#[doc(hidden)]
+static RUNTIME_RX: OnceLock<Mutex<UnboundedReceiver<oneshot::Receiver<TaskResult>>>> =
+    OnceLock::new();
 
 impl From<Result<(), Error>> for TaskResult {
     fn from(result: Result<(), Error>) -> Self {
@@ -41,22 +44,21 @@ impl From<()> for TaskResult {
     }
 }
 
-pub async fn init_task_channel() {
+pub async fn init_task_channel(
+) -> MutexGuard<'static, UnboundedReceiver<oneshot::Receiver<TaskResult>>> {
     // If no receiver is configured, create a new one (with associated sender).
-    RUNTIME_RX
-        .get_or_init(|| async {
-            // Arbitrary limit to 100 simultaneous tasks.
-            let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<UnboundedReceiver<TaskResult>>();
+    let rx = RUNTIME_RX.get_or_init(|| {
+        // Arbitrary limit to 100 simultaneous tasks.
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<oneshot::Receiver<TaskResult>>();
 
-            // Set the runtime sender.
-            RUNTIME_TX
-                .get_or_init(|| async { Mutex::new(Some(tx)) })
-                .await;
+        // Set the runtime sender.
+        RUNTIME_TX.get_or_init(|| Mutex::new(tx));
 
-            // Set the runtime receiver.
-            Mutex::new(Some(rx))
-        })
-        .await;
+        // Set the runtime receiver.
+        Mutex::new(rx)
+    });
+
+    rx.lock()
 }
 
 /// Runs a given future as a Tokio task while ensuring the main function (marked by `#[hermes_five::runtime]`)
@@ -89,15 +91,15 @@ where
     T: Into<TaskResult> + Send + 'static,
 {
     // Create a transmitter(tx)/receiver(rx) unique to this task.
-    let (task_tx, task_rx) = tokio::sync::mpsc::unbounded_channel();
+    let (task_tx, task_rx) = oneshot::channel();
 
     // --
     // Create a task to run our future: note how we capture the tx...
     let handler = task::spawn(async move {
         // ...to send the result of the future through that channel.
         let result = future.await.into();
-        task_tx.send(result).map_err(|err| UnknownError {
-            info: err.to_string(),
+        task_tx.send(result).map_err(|_result: TaskResult| UnknownError {
+            info: "task receiver was closed".to_string(),
         })?;
         Ok(())
     });
@@ -106,8 +108,7 @@ where
     // Send the receiver(rx) side of the task-channel to the runtime.
 
     let cell = RUNTIME_TX.get().ok_or(RuntimeError)?;
-    let mut lock = cell.lock();
-    let runtime_tx = lock.as_mut().ok_or(RuntimeError)?;
+    let runtime_tx = cell.lock();
 
     runtime_tx.send(task_rx).map_err(|err| UnknownError {
         info: err.to_string(),

--- a/hermes-five/src/utils/task.rs
+++ b/hermes-five/src/utils/task.rs
@@ -39,9 +39,7 @@ pub fn setup_rt(test: bool) -> Runtime {
     let mut builder = if test {
         tokio::runtime::Builder::new_current_thread()
     } else {
-        let mut b = tokio::runtime::Builder::new_multi_thread();
-        b.worker_threads(4);
-        b
+        tokio::runtime::Builder::new_multi_thread()
     };
 
     Runtime {
@@ -128,11 +126,13 @@ impl TaskRegistration {
     }
 }
 
+/// Wraps the tokio Runtime: used to customize `block_on` function call.
 pub struct Runtime {
     runtime: tokio::runtime::Runtime,
 }
 
 impl Runtime {
+    /// Runs a future to completion using the underlying Tokio runtime wrapped as a Task.
     pub fn block_on<F: Future>(&self, f: F) -> F::Output {
         self.runtime.block_on(TaskRegistration::run(f))
     }
@@ -140,8 +140,6 @@ impl Runtime {
 
 /// Runs a given future as a Tokio task while ensuring the main function (marked by `#[hermes_five::runtime]`)
 /// will not finish before all tasks running as done.
-/// This is done by using a globally accessible channel to communicate the handlers to be waited by the
-/// runtime.
 ///
 /// # Parameters
 /// * `future`: A future that implements `Future<Output = ()>`, `Send`, and has a `'static` lifetime.

--- a/hermes-five/src/utils/task.rs
+++ b/hermes-five/src/utils/task.rs
@@ -1,10 +1,11 @@
 //! Defines Hermes-Five Runtime task runner.
-use std::sync::OnceLock;
-use std::task::Poll;
-use std::{future::Future, task::ready};
+use std::cell::RefCell;
+use std::future::Future;
+use std::sync::Arc;
 
 use futures::{stream::FuturesUnordered, StreamExt};
 use parking_lot::RwLock;
+use tokio::runtime::Runtime;
 use tokio::sync::oneshot;
 use tokio::task;
 use tokio::task::JoinHandle;
@@ -22,8 +23,12 @@ pub enum TaskResult {
 /// Represents an arc protected handler for a task.
 pub type TaskHandler = JoinHandle<Result<(), Error>>;
 
-static RUNTIME_TASKS: OnceLock<RwLock<FuturesUnordered<oneshot::Receiver<TaskResult>>>> =
-    OnceLock::new();
+type Task = oneshot::Receiver<TaskResult>;
+type Queue = Arc<RwLock<FuturesUnordered<Task>>>;
+
+thread_local! {
+    static TASKS: RefCell<Option<Queue>> = const { RefCell::new(None) };
+}
 
 impl From<Result<(), Error>> for TaskResult {
     fn from(result: Result<(), Error>) -> Self {
@@ -40,33 +45,73 @@ impl From<()> for TaskResult {
     }
 }
 
-pub fn init_task_channel() -> TaskQueueConsumer {
+pub fn setup_rt(test: bool) -> TaskQueueConsumer {
+    let task_queue = Arc::new(RwLock::new(FuturesUnordered::new()));
+
+    let mut builder = if test {
+        tokio::runtime::Builder::new_current_thread()
+    } else {
+        let mut b = tokio::runtime::Builder::new_multi_thread();
+        b.worker_threads(4);
+        b
+    };
+
+    let queue = task_queue.clone();
+    builder.enable_all().on_thread_start(move || {
+        init_thread(queue.clone());
+    });
+
     TaskQueueConsumer {
-        queue: RUNTIME_TASKS.get_or_init(|| RwLock::new(FuturesUnordered::new())),
+        runtime: builder.build().unwrap(),
+        queue: task_queue,
     }
 }
 
+fn init_thread(queue: Queue) -> Option<Queue> {
+    TASKS.with_borrow_mut(|t| std::mem::replace(t, Some(queue)))
+}
+
 pub struct TaskQueueConsumer {
-    queue: &'static RwLock<FuturesUnordered<oneshot::Receiver<TaskResult>>>,
+    runtime: Runtime,
+    queue: Queue,
 }
 
 impl TaskQueueConsumer {
-    pub async fn wait(self) {
-        futures::stream::poll_fn(|cx| self.queue.write().poll_next_unpin(cx))
-            .for_each(|task_result| async {
-                match task_result {
-                    Ok(TaskResult::Ok) => {}
-                    Err(_) => {
-                        log::error!("Task aborted");
-                        eprintln!("Task aborted");
-                    }
-                    Ok(TaskResult::Err(err)) => {
-                        log::error!("Task failed: {:?}", err.to_string());
-                        eprintln!("Task failed: {:?}", err.to_string());
-                    }
+    pub fn block_on<F: Future>(&self, f: F) -> F::Output {
+        struct ResetQueue(Option<Queue>);
+        impl Drop for ResetQueue {
+            fn drop(&mut self) {
+                if let Some(queue) = self.0.take() {
+                    init_thread(queue);
+                } else {
+                    TASKS.with_borrow_mut(|t| t.take());
                 }
-            })
-            .await
+            }
+        }
+
+        let _guard = ResetQueue(init_thread(self.queue.clone()));
+        self.runtime.block_on(async {
+            let res = f.await;
+
+            // wait for tasks to complete.
+            futures::stream::poll_fn(|cx| self.queue.write().poll_next_unpin(cx))
+                .for_each(|task_result| async {
+                    match task_result {
+                        Ok(TaskResult::Ok) => {}
+                        Err(_) => {
+                            log::error!("Task aborted");
+                            eprintln!("Task aborted");
+                        }
+                        Ok(TaskResult::Err(err)) => {
+                            log::error!("Task failed: {:?}", err.to_string());
+                            eprintln!("Task failed: {:?}", err.to_string());
+                        }
+                    }
+                })
+                .await;
+
+            res
+        })
     }
 }
 
@@ -114,8 +159,11 @@ where
             })
     });
 
-    let tasks = RUNTIME_TASKS.get().ok_or(RuntimeError)?;
-    tasks.read().push(task_rx);
+    TASKS.with_borrow(|r| {
+        r.as_deref()
+            .ok_or(RuntimeError)
+            .map(|tasks| tasks.read().push(task_rx))
+    })?;
 
     Ok(handler)
 }

--- a/hermes-five/src/utils/task.rs
+++ b/hermes-five/src/utils/task.rs
@@ -1,14 +1,11 @@
 //! Defines Hermes-Five Runtime task runner.
-use std::cell::RefCell;
 use std::future::Future;
-use std::sync::Arc;
+use std::panic::AssertUnwindSafe;
 
-use futures::{stream::FuturesUnordered, StreamExt};
-use parking_lot::RwLock;
-use tokio::runtime::Runtime;
-use tokio::sync::oneshot;
-use tokio::task;
+use futures::FutureExt;
+use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
+use tokio::{task, task_local};
 
 use crate::errors::{Error, RuntimeError, UnknownError};
 
@@ -22,13 +19,6 @@ pub enum TaskResult {
 
 /// Represents an arc protected handler for a task.
 pub type TaskHandler = JoinHandle<Result<(), Error>>;
-
-type Task = oneshot::Receiver<TaskResult>;
-type Queue = Arc<RwLock<FuturesUnordered<Task>>>;
-
-thread_local! {
-    static TASKS: RefCell<Option<Queue>> = const { RefCell::new(None) };
-}
 
 impl From<Result<(), Error>> for TaskResult {
     fn from(result: Result<(), Error>) -> Self {
@@ -45,9 +35,7 @@ impl From<()> for TaskResult {
     }
 }
 
-pub fn setup_rt(test: bool) -> TaskQueueConsumer {
-    let task_queue = Arc::new(RwLock::new(FuturesUnordered::new()));
-
+pub fn setup_rt(test: bool) -> Runtime {
     let mut builder = if test {
         tokio::runtime::Builder::new_current_thread()
     } else {
@@ -56,62 +44,97 @@ pub fn setup_rt(test: bool) -> TaskQueueConsumer {
         b
     };
 
-    let queue = task_queue.clone();
-    builder.enable_all().on_thread_start(move || {
-        init_thread(queue.clone());
-    });
-
-    TaskQueueConsumer {
-        runtime: builder.build().unwrap(),
-        queue: task_queue,
+    Runtime {
+        runtime: builder.enable_all().build().unwrap(),
     }
 }
 
-fn init_thread(queue: Queue) -> Option<Queue> {
-    TASKS.with_borrow_mut(|t| std::mem::replace(t, Some(queue)))
+task_local! {
+    /// The current task registration.
+    static TASK: TaskRegistration;
 }
 
-pub struct TaskQueueConsumer {
-    runtime: Runtime,
-    queue: Queue,
+#[derive(Clone)]
+struct TaskRegistration {
+    // Tasks will not send anything if they exited without error.
+    // Tasks will not send anything if they were explicitly aborted.
+    // Tasks will send an error if they exited with error or panicked.
+    results: mpsc::UnboundedSender<Error>,
 }
 
-impl TaskQueueConsumer {
-    pub fn block_on<F: Future>(&self, f: F) -> F::Output {
-        struct ResetQueue(Option<Queue>);
-        impl Drop for ResetQueue {
-            fn drop(&mut self) {
-                if let Some(queue) = self.0.take() {
-                    init_thread(queue);
-                } else {
-                    TASKS.with_borrow_mut(|t| t.take());
-                }
+impl TaskRegistration {
+    /// Get a handle to the current task context.
+    fn get() -> Result<Self, Error> {
+        TASK.try_with(|t| t.clone()).map_err(|_| RuntimeError)
+    }
+
+    /// Runs a future within the current task context.
+    async fn catch_errors<F, T>(self, future: F) -> Result<(), Error>
+    where
+        F: Future<Output = T> + Send + 'static,
+        T: Into<TaskResult> + Send + 'static,
+    {
+        // allow ourselves to catch panics
+        let future = AssertUnwindSafe(future).catch_unwind();
+
+        // run our future within the scope our task queue.
+        let mut task = std::pin::pin!(TASK.scope(self, future));
+
+        // await the future response.
+        let res = task.as_mut().await;
+
+        // get back our task queue.
+        let queue = task.take_value().ok_or(RuntimeError)?;
+
+        // check for a panic.
+        let res: TaskResult = match res {
+            Ok(res) => res.into(),
+            Err(panic) => {
+                // ignore errors if receiver is missing.
+                _ = queue.results.send(UnknownError {
+                    info: "task panicked".to_string(),
+                });
+
+                // continue the panic.
+                std::panic::resume_unwind(panic);
             }
+        };
+
+        // send error, if there was one.
+        if let TaskResult::Err(e) = res {
+            queue.results.send(e).map_err(|_| RuntimeError)?;
         }
 
-        let _guard = ResetQueue(init_thread(self.queue.clone()));
-        self.runtime.block_on(async {
-            let res = f.await;
+        Ok(())
+    }
 
-            // wait for tasks to complete.
-            futures::stream::poll_fn(|cx| self.queue.write().poll_next_unpin(cx))
-                .for_each(|task_result| async {
-                    match task_result {
-                        Ok(TaskResult::Ok) => {}
-                        Err(_) => {
-                            log::error!("Task aborted");
-                            eprintln!("Task aborted");
-                        }
-                        Ok(TaskResult::Err(err)) => {
-                            log::error!("Task failed: {:?}", err.to_string());
-                            eprintln!("Task failed: {:?}", err.to_string());
-                        }
-                    }
-                })
-                .await;
+    /// Create a new task context, run a task inside it,
+    /// and wait for all tasks to complete.
+    async fn run<F: Future>(f: F) -> F::Output {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let task = Self { results: tx };
 
-            res
-        })
+        // run our future within the scope our task queue.
+        let res = TASK.scope(task, f).await;
+
+        // wait for tasks to complete.
+        // recv returns None if all corresponding senders are dropped.
+        while let Some(err) = rx.recv().await {
+            log::error!("Task failed: {:?}", err.to_string());
+            eprintln!("Task failed: {:?}", err.to_string());
+        }
+
+        res
+    }
+}
+
+pub struct Runtime {
+    runtime: tokio::runtime::Runtime,
+}
+
+impl Runtime {
+    pub fn block_on<F: Future>(&self, f: F) -> F::Output {
+        self.runtime.block_on(TaskRegistration::run(f))
     }
 }
 
@@ -144,28 +167,11 @@ where
     F: Future<Output = T> + Send + 'static,
     T: Into<TaskResult> + Send + 'static,
 {
-    // Create a transmitter(tx)/receiver(rx) unique to this task.
-    let (task_tx, task_rx) = oneshot::channel();
+    let task = TaskRegistration::get()?;
 
-    // --
-    // Create a task to run our future: note how we capture the tx...
-    let handler = task::spawn(async move {
-        // ...to send the result of the future through that channel.
-        let result = future.await.into();
-        task_tx
-            .send(result)
-            .map_err(|_result: TaskResult| UnknownError {
-                info: "task receiver was closed".to_string(),
-            })
-    });
-
-    TASKS.with_borrow(|r| {
-        r.as_deref()
-            .ok_or(RuntimeError)
-            .map(|tasks| tasks.read().push(task_rx))
-    })?;
-
-    Ok(handler)
+    // Create a task to run our future: note how we capture `task`.
+    // This `task` acts as a token to keep track of active tasks.
+    Ok(task::spawn(async move { task.catch_errors(future).await }))
 }
 
 #[macro_export]


### PR DESCRIPTION
👋 As discussed, here's a PR to clean up the task queue system a bit.

This changes how the runtime is constructed, as well as how tasks are automatically awaited.

We move more of the runtime construction logic out of macros to functions in utils/task.rs. This allows the macro logic to be a lot more concise and understandable.

The task waiting is completely changed. It now offers an mpsc queue per runtime, rather than a global one. This avoids all requirements of locks within the task system. The block_on function constructs the receiver when it's needed, and for all tasks that are spawned, the sender is cloned and passed into the task.

This sender is stored in a task-local which is how we allow tasks to spawn other tasks.

When a task completes, if there was an error/panic, it sends a message over the channel with the error that occurred. No matter the result, the sender is then dropped. When all senders are dropped, the receiver will be able to detect that, and exit the loop.

I've added many comments throughout the code, do let me know if there's anything that doesn't quite make sense.