### PR TITLE
Refactor event type to use strong type checking.

### DIFF
--- a/hermes-five/src/animations/animation.rs
+++ b/hermes-five/src/animations/animation.rs
@@ -3,31 +3,24 @@ use std::fmt::{Display, Formatter};
 use parking_lot::RwLock;
 
 use crate::errors::Error;
-use crate::utils::{task, EventHandler, EventManager, TaskHandler};
+use crate::utils::{task, EventHandler, EventManager, EventType, TaskHandler};
 
 use crate::animations::{Segment, Track};
+use crate::create_event_type;
 use std::sync::Arc;
 
-/// Lists all events a Animation can emit/listen.
-pub enum AnimationEvent {
-    /// Triggered when the animation starts.
-    OnSegmentDone,
-    /// Triggered when the animation starts.
-    OnStart,
-    /// Triggered when the animation finishes.
-    OnComplete,
-}
+create_event_type!(OnStartEvent, Animation);
+create_event_type!(OnCompleteEvent, Animation);
+create_event_type!(OnSegmentDoneEvent, Segment);
 
-/// Convert events to string to facilitate usage with [`EventManager`].
-impl From<AnimationEvent> for String {
-    fn from(event: AnimationEvent) -> Self {
-        let event = match event {
-            AnimationEvent::OnSegmentDone => "segment_done",
-            AnimationEvent::OnStart => "start",
-            AnimationEvent::OnComplete => "complete",
-        };
-        event.into()
-    }
+/// Lists all events an Animation can emit/listen with the expected payload type.
+pub enum AnimationEvent {
+    // Triggered when the animation starts, argument is an integer.
+    OnSegmentDone(OnSegmentDoneEvent),
+    // Triggered when the animation starts, argument is a String.
+    OnStart(OnStartEvent),
+    // Triggered when the animation finishes, argument is an Animation object.
+    OnComplete(OnCompleteEvent),
 }
 
 /// Represents an animation: a collection of ordered [`Segment`] to be run in sequence.
@@ -111,7 +104,7 @@ impl Animation {
         let events_clone = self.events.clone();
         let mut self_clone = self.clone();
 
-        self.events.emit(AnimationEvent::OnStart, self.clone());
+        self.events.emit(OnStartEvent, self.clone());
         if self.get_duration() > 0 {
             let handler = task::run(async move {
                 // Loop through the segments and run them one by one.
@@ -121,12 +114,12 @@ impl Animation {
                     // Retrieve the currently running segment.
                     let segment_playing = self_clone.segments.get_mut(index).unwrap();
                     segment_playing.play().await?;
-                    events_clone.emit(AnimationEvent::OnSegmentDone, segment_playing.clone());
+                    events_clone.emit(OnSegmentDoneEvent, segment_playing.clone());
                 }
 
                 *self_clone.current.write() = 0; // reset to the beginning
                 *self_clone.interval.write() = None;
-                events_clone.emit(AnimationEvent::OnComplete, self_clone);
+                events_clone.emit(OnCompleteEvent, self_clone);
                 Ok(())
             })
             .unwrap();
@@ -302,11 +295,11 @@ impl Animation {
     ///     });
     /// }
     /// ```
-    pub fn on<S, F, T, Fut>(&self, event: S, callback: F) -> EventHandler
+    pub fn on<T, E, F, Fut>(&self, event: E, callback: F) -> EventHandler
     where
-        S: Into<String>,
-        T: 'static + Send + Sync + Clone,
-        F: FnMut(T) -> Fut + Send + 'static,
+        T: EventType,
+        E: Into<T>,
+        F: FnMut(T::Argument) -> Fut + Send + 'static,
         Fut: std::future::Future<Output = Result<(), Error>> + Send + 'static,
     {
         self.events.on(event, callback)

--- a/hermes-five/src/devices/input/analog.rs
+++ b/hermes-five/src/devices/input/analog.rs
@@ -3,13 +3,13 @@ use std::sync::Arc;
 
 use parking_lot::RwLock;
 
-use crate::devices::input::{Input, InputEvent};
+use crate::devices::input::{Input, InputEvent, OnChangeEvent};
 use crate::devices::Device;
 use crate::errors::Error;
 use crate::hardware::Hardware;
 use crate::io::{IoProtocol, PinIdOrName, PinModeId};
 use crate::pause;
-use crate::utils::task;
+use crate::utils::{task, EventType};
 use crate::utils::{EventHandler, EventManager, State, TaskHandler};
 
 /// Represents an analog sensor of unspecified type: an [`Input`] [`Device`] that reads analog values
@@ -96,7 +96,7 @@ impl AnalogInput {
                         let state_value = *self_clone.state.read();
                         if pin_value != state_value {
                             *self_clone.state.write() = pin_value;
-                            self_clone.events.emit(InputEvent::OnChange, pin_value);
+                            self_clone.events.emit(OnChangeEvent, pin_value.into());
                         }
 
                         // Change can only be done 10x a sec. to avoid bouncing.
@@ -157,11 +157,11 @@ impl AnalogInput {
     ///     });
     /// }
     /// ```
-    pub fn on<S, F, T, Fut>(&self, event: S, callback: F) -> EventHandler
+    pub fn on<T, E, F, Fut>(&self, event: E, callback: F) -> EventHandler
     where
-        S: Into<String>,
-        T: 'static + Send + Sync + Clone,
-        F: FnMut(T) -> Fut + Send + 'static,
+        T: EventType,
+        E: Into<T>,
+        F: FnMut(T::Argument) -> Fut + Send + 'static,
         Fut: std::future::Future<Output = Result<(), Error>> + Send + 'static,
     {
         self.events.on(event, callback)

--- a/hermes-five/src/devices/input/button.rs
+++ b/hermes-five/src/devices/input/button.rs
@@ -4,11 +4,12 @@ use std::sync::Arc;
 use parking_lot::RwLock;
 
 use crate::devices::{Device, Input, InputEvent};
+use crate::devices::input::{OnChangeEvent, OnPressEvent, OnReleaseEvent};
 use crate::errors::Error;
 use crate::hardware::Hardware;
 use crate::io::{IoProtocol, PinIdOrName, PinModeId};
 use crate::pause;
-use crate::utils::{task, EventHandler, EventManager, State, TaskHandler};
+use crate::utils::{task, EventHandler, EventManager, EventType, State, TaskHandler};
 
 /// Represents a simple push button as an input of the board.
 /// <https://docs.arduino.cc/built-in-examples/digital/Button>
@@ -212,18 +213,18 @@ impl Button {
 
                             // Depending on logical inversion mode, pin_value is inverted.
                             match self_clone.invert {
-                                false => self_clone.events.emit(InputEvent::OnChange, pin_value),
-                                true => self_clone.events.emit(InputEvent::OnChange, !pin_value),
+                                false => self_clone.events.emit(OnChangeEvent, pin_value.into()),
+                                true => self_clone.events.emit(OnChangeEvent, State::from(!pin_value)),
                             };
 
                             match self_clone.pullup {
                                 true => match pin_value {
-                                    true => self_clone.events.emit(InputEvent::OnRelease, ()),
-                                    false => self_clone.events.emit(InputEvent::OnPress, ()),
+                                    true => self_clone.events.emit(OnReleaseEvent, ()),
+                                    false => self_clone.events.emit(OnPressEvent, ()),
                                 },
                                 false => match pin_value {
-                                    true => self_clone.events.emit(InputEvent::OnPress, ()),
-                                    false => self_clone.events.emit(InputEvent::OnRelease, ()),
+                                    true => self_clone.events.emit(OnPressEvent, ()),
+                                    false => self_clone.events.emit(OnReleaseEvent, ()),
                                 },
                             };
                         }
@@ -290,11 +291,11 @@ impl Button {
     ///     });
     /// }
     /// ```
-    pub fn on<S, F, T, Fut>(&self, event: S, callback: F) -> EventHandler
+    pub fn on<T, E, F, Fut>(&self, event: E, callback: F) -> EventHandler
     where
-        S: Into<String>,
-        T: 'static + Send + Sync + Clone,
-        F: FnMut(T) -> Fut + Send + 'static,
+        T: EventType,
+        E: Into<T>,
+        F: FnMut(T::Argument) -> Fut + Send + 'static,
         Fut: std::future::Future<Output = Result<(), Error>> + Send + 'static,
     {
         self.events.on(event, callback)

--- a/hermes-five/src/devices/input/digital.rs
+++ b/hermes-five/src/devices/input/digital.rs
@@ -3,13 +3,13 @@ use std::sync::Arc;
 
 use parking_lot::RwLock;
 
-use crate::devices::input::{Input, InputEvent};
+use crate::devices::input::{Input, InputEvent, OnChangeEvent, OnHighEvent, OnLowEvent};
 use crate::devices::Device;
 use crate::errors::Error;
 use crate::hardware::Hardware;
 use crate::io::{IoProtocol, PinIdOrName, PinModeId};
 use crate::pause;
-use crate::utils::{task, EventHandler, EventManager, State, TaskHandler};
+use crate::utils::{task, EventHandler, EventManager, EventType, State, TaskHandler};
 
 /// Represents a digital sensor of unspecified type: an [`Input`] [`Device`] that reads digital values
 /// from an INPUT compatible pin.
@@ -96,10 +96,10 @@ impl DigitalInput {
                         let state_value = *self_clone.state.read();
                         if pin_value != state_value {
                             *self_clone.state.write() = pin_value;
-                            self_clone.events.emit(InputEvent::OnChange, pin_value);
+                            self_clone.events.emit(OnChangeEvent, pin_value.into());
                             match pin_value {
-                                true => self_clone.events.emit(InputEvent::OnHigh, ()),
-                                false => self_clone.events.emit(InputEvent::OnLow, ()),
+                                true => self_clone.events.emit(OnHighEvent, ()),
+                                false => self_clone.events.emit(OnLowEvent, ()),
                             }
                         }
 
@@ -165,11 +165,11 @@ impl DigitalInput {
     ///     });
     /// }
     /// ```
-    pub fn on<S, F, T, Fut>(&self, event: S, callback: F) -> EventHandler
+    pub fn on<T, E, F, Fut>(&self, event: E, callback: F) -> EventHandler
     where
-        S: Into<String>,
-        T: 'static + Send + Sync + Clone,
-        F: FnMut(T) -> Fut + Send + 'static,
+        T: EventType,
+        E: Into<T>,
+        F: FnMut(T::Argument) -> Fut + Send + 'static,
         Fut: std::future::Future<Output = Result<(), Error>> + Send + 'static,
     {
         self.events.on(event, callback)

--- a/hermes-five/src/devices/input/mod.rs
+++ b/hermes-five/src/devices/input/mod.rs
@@ -1,3 +1,4 @@
+use crate::create_event_type;
 use crate::devices::Device;
 use crate::utils::State;
 
@@ -16,30 +17,22 @@ pub trait Input: Device {
 }
 dyn_clone::clone_trait_object!(Input);
 
+create_event_type!(OnChangeEvent, State);
+create_event_type!(OnPressEvent, ());
+create_event_type!(OnReleaseEvent, ());
+create_event_type!(OnHighEvent, ());
+create_event_type!(OnLowEvent, ());
+
 /// Lists all events a Input type device can emit/listen.
 pub enum InputEvent {
     /// Triggered when the Input value changes.
-    OnChange,
+    OnChange(OnChangeEvent),
     /// Triggered when the button is pressed.
-    OnPress,
+    OnPress(()),
     /// Triggered when the button is released.
-    OnRelease,
+    OnRelease(()),
     /// Triggered when a value changes to HIGH.
-    OnHigh,
+    OnHigh(()),
     /// Triggered when a value changes to LOW.
-    OnLow,
-}
-
-/// Convert events to string to facilitate usage with [`EventManager`](crate::utils::EventManager).
-impl From<InputEvent> for String {
-    fn from(value: InputEvent) -> Self {
-        let event = match value {
-            InputEvent::OnChange => "change",
-            InputEvent::OnPress => "press",
-            InputEvent::OnRelease => "release",
-            InputEvent::OnHigh => "high",
-            InputEvent::OnLow => "low",
-        };
-        event.into()
-    }
+    OnLow(()),
 }

--- a/hermes-five/src/errors.rs
+++ b/hermes-five/src/errors.rs
@@ -17,8 +17,8 @@ pub enum Error {
     ProtocolError { source: ProtocolError },
     /// Hardware error: {source}.
     HardwareError { source: HardwareError },
-    /// Unknown error: {info}.
-    UnknownError { info: String },
+    /// Error: {info}.
+    MiscError { info: String },
 }
 
 impl From<std::io::Error> for Error {
@@ -49,7 +49,7 @@ impl From<HardwareError> for Error {
 
 impl From<Utf8Error> for Error {
     fn from(value: Utf8Error) -> Self {
-        UnknownError {
+        MiscError {
             info: value.to_string(),
         }
     }
@@ -119,12 +119,12 @@ mod tests {
             "Hardware error: Pin (1) not compatible with mode (SERVO) - test context."
         );
 
-        let unknown_error = UnknownError {
+        let unknown_error = MiscError {
             info: "Some unknown error".to_string(),
         };
         assert_eq!(
             format!("{}", unknown_error),
-            "Unknown error: Some unknown error."
+            "Error: Some unknown error."
         );
     }
 

--- a/hermes-five/src/hardware/board.rs
+++ b/hermes-five/src/hardware/board.rs
@@ -2,29 +2,21 @@ use crate::errors::Error;
 use crate::hardware::Hardware;
 use crate::io::{IoData, IoTransport, RemoteIo, IO};
 use crate::io::{IoProtocol, PinModeId};
-use crate::utils::{task, Range};
+use crate::utils::{task, EventType, Range};
 use crate::utils::{EventHandler, EventManager};
 use parking_lot::RwLock;
 use std::fmt::Display;
 use std::sync::Arc;
+use crate::create_event_type;
 
 /// Lists all events a Board can emit/listen.
+create_event_type!(OnReadyEvent, Board);
+create_event_type!(OnCloseEvent, Board);
 pub enum BoardEvent {
     /// Triggered when the board connexion is established and the handshake has been made.
-    OnReady,
+    OnReady(OnReadyEvent),
     /// Triggered when the board connexion is closed (gracefully).
-    OnClose,
-}
-
-/// Convert events to string to facilitate usage with [`EventManager`].
-impl From<BoardEvent> for String {
-    fn from(value: BoardEvent) -> Self {
-        let event = match value {
-            BoardEvent::OnReady => "ready",
-            BoardEvent::OnClose => "close",
-        };
-        event.into()
-    }
+    OnClose(OnCloseEvent),
 }
 
 /// Represents a physical board (Arduino most-likely) where your [`crate::devices::Device`] can be attached and controlled through this API.
@@ -162,7 +154,7 @@ impl Board {
 
         task::run(async move {
             let board = callback_board.blocking_open()?;
-            events_clone.emit(BoardEvent::OnReady, board);
+            events_clone.emit(OnReadyEvent, board);
             Ok(())
         })
         .expect("Task failed");
@@ -202,7 +194,7 @@ impl Board {
         let callback_board = self.clone();
         task::run(async move {
             let board = callback_board.blocking_close()?;
-            events.emit(BoardEvent::OnClose, board);
+            events.emit(OnCloseEvent, board);
             Ok(())
         })
         .expect("Task failed");
@@ -250,11 +242,11 @@ impl Board {
     ///     });
     /// }
     /// ```
-    pub fn on<S, F, T, Fut>(&self, event: S, callback: F) -> EventHandler
+    pub fn on<T, E, F, Fut>(&self, event: E, callback: F) -> EventHandler
     where
-        S: Into<String>,
-        T: 'static + Send + Sync + Clone,
-        F: FnMut(T) -> Fut + Send + 'static,
+        T: EventType,
+        E: Into<T>,
+        F: FnMut(T::Argument) -> Fut + Send + 'static,
         Fut: std::future::Future<Output = Result<(), Error>> + Send + 'static,
     {
         self.events.on(event, callback)

--- a/hermes-five/src/hardware/mod.rs
+++ b/hermes-five/src/hardware/mod.rs
@@ -6,6 +6,7 @@ mod pca9685;
 use crate::io::{IoProtocol, IO};
 pub use board::Board;
 pub use board::BoardEvent;
+pub use board::OnReadyEvent;
 pub use pca9685::PCA9685;
 
 /// You most likely don't need this function (outside this crate).

--- a/hermes-five/src/hardware/pca9685.rs
+++ b/hermes-five/src/hardware/pca9685.rs
@@ -2,7 +2,7 @@
 // All information are relative to PCA9685 datasheets:
 // https://www.digikey.jp/htmldatasheets/production/2459480/0/0/1/pca9685.html
 
-use crate::errors::{Error, HardwareError, UnknownError};
+use crate::errors::{Error, HardwareError, MiscError};
 use crate::hardware::{Board, Expander, Hardware};
 use crate::io::{IoData, IoProtocol, Pin, PinMode, PinModeId, IO};
 use crate::utils::{Range, Scalable};
@@ -123,7 +123,7 @@ impl PCA9685 {
     pub fn set_frequency(&mut self, frequency: u16) -> Result<&Self, Error> {
         // Validate frequency range
         if !(Self::MIN_FREQUENCY..=Self::MAX_FREQUENCY).contains(&frequency) {
-            return Err(UnknownError {
+            return Err(MiscError {
                 info: format!(
                     "Frequency must be between {} and {} Hz",
                     Self::MIN_FREQUENCY,

--- a/hermes-five/src/io/data.rs
+++ b/hermes-five/src/io/data.rs
@@ -287,7 +287,7 @@ impl PinModeId {
             0x0E => Ok(PinModeId::TONE),
             0x0F => Ok(PinModeId::DHT),
             0x7F => Ok(PinModeId::UNSUPPORTED),
-            x => Err(UnknownError {
+            x => Err(MiscError {
                 info: format!("PinMode not found with value: {}", x),
             }),
         }

--- a/hermes-five/src/utils/events.rs
+++ b/hermes-five/src/utils/events.rs
@@ -22,6 +22,82 @@ struct CallbackWrapper {
 }
 type SyncedCallbackMap = Mutex<HashMap<String, Vec<CallbackWrapper>>>;
 
+/// An event type specifies its NAME and `Argument` type used for the `on`/`emit` methods.
+pub trait EventType {
+    type Argument: 'static + Send + Sync + Clone;
+    const NAME: &'static str;
+}
+
+/// Defines a new event type implementing the [`EventType`] trait.
+///
+/// This macro generates a struct and implements the [`EventType`] trait for it,
+/// including the required `Argument` type and the event's static `ID`.
+///
+/// # Syntax
+///
+/// - `StructName`: The name of the event type struct to define.
+/// - `"event_name"` (optional): A static string identifier for the event (used for matching, logging, etc.). The `StructName` by default
+/// - `ArgumentType`: The type of the payload carried by the event.
+///
+/// # Example
+///
+/// ```rust
+/// use hermes_five::create_event_type;
+/// use hermes_five::utils::EventType;
+///
+/// struct MyPayload;
+///
+/// create_event_type!(MyEvent, MyPayload);
+/// ```
+#[macro_export]
+macro_rules! create_event_type {
+    // Case with explicit event name
+    ($struct_name:ident, $event_name:literal, $arg_ty:ty) => {
+        pub struct $struct_name;
+
+        impl $crate::utils::EventType for $struct_name {
+            type Argument = $arg_ty;
+            const NAME: &'static str = $event_name;
+        }
+    };
+
+    // Case without explicit event name
+    ($struct_name:ident, $arg_ty:ty) => {
+        pub struct $struct_name;
+
+        impl $crate::utils::EventType for $struct_name {
+            type Argument = $arg_ty;
+            const NAME: &'static str = stringify!($struct_name);
+        }
+    };
+}
+
+// Interne — ne pas exporter
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __create_event_type_internal {
+    ($struct_name:ident, $event_name:literal, $arg_ty:ty) => {
+        pub struct $struct_name;
+
+        impl $crate::EventType for $struct_name {
+            type Argument = $arg_ty;
+            const NAME: &'static str = $event_name;
+        }
+    };
+}
+
+macro_rules! _create_event_type {
+    // Case with explicit event name
+    ($struct_name:ident, $event_name:literal, $arg_ty:ty) => {
+        pub struct $struct_name;
+
+        impl $crate::EventType for $struct_name {
+            type Argument = $arg_ty;
+            const NAME: &'static str = $event_name;
+        }
+    };
+}
+
 #[derive(Clone, Default)]
 pub struct EventManager {
     callbacks: Arc<SyncedCallbackMap>,
@@ -74,20 +150,20 @@ impl EventManager {
     ///     events.emit("ready", ("bar"));
     /// }
     /// ```
-    pub fn on<S, F, T, Fut>(&self, event: S, mut callback: F) -> EventHandler
+    pub fn on<T, E, F, Fut>(&self, _: E, mut callback: F) -> EventHandler
     where
-        S: Into<String>,
-        T: 'static + Send + Sync + Clone,
-        F: FnMut(T) -> Fut + Send + 'static,
+        T: EventType,
+        E: Into<T>,
+        F: FnMut(T::Argument) -> Fut + Send + 'static,
         Fut: std::future::Future<Output = Result<(), Error>> + Send + 'static,
     {
-        let event_name = event.into();
+        let event_name: String = T::NAME.into();
         // Generate a unique ID.
         let id = self.next_id.fetch_add(1, Ordering::Relaxed);
         // Boxes the callback and downcast its parameter.
         let boxed_callback =
             Box::new(
-                move |arg: Arc<dyn Any + Send + Sync>| match arg.downcast::<T>() {
+                move |arg: Arc<dyn Any + Send + Sync>| match arg.downcast::<T::Argument>() {
                     Ok(arg) => callback((*arg).clone()).boxed(),
                     Err(_) => Box::pin(async { Ok(()) }),
                 },
@@ -146,13 +222,12 @@ impl EventManager {
     ///     events.emit("nothing", ());
     /// }
     /// ```
-    pub fn emit<S, T>(&self, event: S, payload: T)
+    pub fn emit<E>(&self, event: E, payload: E::Argument)
     where
-        S: Into<String>,
-        T: 'static + Send + Sync,
+        E: EventType
     {
         let payload_any: Arc<dyn Any + Send + Sync> = Arc::new(payload);
-        if let Some(callbacks) = self.callbacks.lock().get_mut(&event.into()) {
+        if let Some(callbacks) = self.callbacks.lock().get_mut(E::NAME) {
             for wrapper in callbacks.iter_mut() {
                 let payload_clone = payload_any.clone();
                 let future = (wrapper.callback)(payload_clone);

--- a/hermes-five/src/utils/task.rs
+++ b/hermes-five/src/utils/task.rs
@@ -7,7 +7,7 @@ use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tokio::{task, task_local};
 
-use crate::errors::{Error, RuntimeError, UnknownError};
+use crate::errors::{Error, RuntimeError, MiscError};
 
 /// Represents the result of a TaskResult.
 /// A task may return either () or Result<(), Error> for flexibility which
@@ -89,7 +89,7 @@ impl TaskRegistration {
             Ok(res) => res.into(),
             Err(panic) => {
                 // ignore errors if receiver is missing.
-                _ = queue.results.send(UnknownError {
+                _ = queue.results.send(MiscError {
                     info: "task panicked".to_string(),
                 });
 
@@ -194,7 +194,7 @@ mod tests {
 
     use serial_test::serial;
 
-    use crate::errors::{Error, UnknownError};
+    use crate::errors::{Error, MiscError};
     use crate::utils::task;
 
     #[hermes_five_macros::runtime]
@@ -311,7 +311,7 @@ mod tests {
         assert!(task.is_ok(), "An Ok(()) task do not panic the runtime");
 
         let task = task::run(async move {
-            Err(UnknownError {
+            Err(MiscError {
                 info: "wow panic!".to_string(),
             })
         });


### PR DESCRIPTION
@conradludgate I’ve been working on refactoring the event types, and I’ve put together a draft (you’ll see that it doesn’t compile the examples yet).
I’m running into difficulties maintaining the simplicity of the event API while still handling various callback return types. For example, the "OnChange" event (as seen in examples/button/inverted.rs) requires flexibility, but I’m concerned that by making this flexible, we might bypass Rust’s type system, which could lead to safety issues. On the other hand, if we stick to strictly typed callbacks, we lose some flexibility.

Could you share your thoughts on how to balance these concerns and about this PR ?

As a side note, do you think the EventManager could be useful as a standalone crate contributed to the ecosystem?