### PR TITLE
Fix issue 4: pause! macro requires dependent crates to explicitly dep…

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,3 +40,8 @@ jobs:
         run: cargo test --workspace --verbose --color=always
         env:
           RUST_BACKTRACE: 1
+
+      - name: Test compiling external project using Hermes-Five library
+        run: |
+          cd hermes-five/tests/compile_tests
+          cargo check

--- a/hermes-five/src/lib.rs
+++ b/hermes-five/src/lib.rs
@@ -80,6 +80,8 @@
 #[cfg(test)]
 extern crate self as hermes_five;
 
+pub extern crate tokio;
+
 pub mod animations;
 pub mod devices;
 pub mod errors;

--- a/hermes-five/src/utils/task.rs
+++ b/hermes-five/src/utils/task.rs
@@ -175,7 +175,7 @@ where
 #[macro_export]
 macro_rules! pause {
     ($ms:expr) => {
-        tokio::time::sleep(tokio::time::Duration::from_millis($ms as u64)).await
+        $crate::tokio::time::sleep($crate::tokio::time::Duration::from_millis($ms as u64)).await
     };
 }
 

--- a/hermes-five/tests/compile_tests/Cargo.toml
+++ b/hermes-five/tests/compile_tests/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "compile_tests"
+description = "Tests use of Hermes-Five as a library"
+version = "0.1.0"
+edition = "2021"
+
+[workspace]
+
+[dependencies]
+hermes-five = { path = "../../" }

--- a/hermes-five/tests/compile_tests/src/main.rs
+++ b/hermes-five/tests/compile_tests/src/main.rs
@@ -1,0 +1,6 @@
+use hermes_five::pause;
+
+#[hermes_five::runtime]
+async fn main() {
+    pause!(500);
+}


### PR DESCRIPTION
**Background**
The `pause!` macro in hermes_five relies on `tokio::time::sleep().await` but did not re-export tokio.
As a result, dependent crates had to explicitly add tokio to their own Cargo.toml, which is inconvenient and unnecessary.

**What this PR does**
- Adds `pub extern crate tokio;` in hermes_five to re-export the tokio crate.
- Modifies the pause! macro to call `$crate::tokio::time::sleep` and `$crate::tokio::time::Duration`, ensuring it always uses the tokio bundled with hermes_five.
- Add functional test and CI step to check an external project can use pause! without explicit dependencies.

This fixes the issue and lets users call `pause!` without needing to add tokio manually.

**Notes**
- This is a backward-compatible fix that does not change runtime behavior.
- No API changes or major version bump needed.
- The PR introduces code coverage via CI actions which needs manual check
