### PR TITLE
Rename `Output` to `OutputDevice` and introduce sealed trait for reus…

### DIFF
--- a/hermes-five/examples/io/remote_serial.rs
+++ b/hermes-five/examples/io/remote_serial.rs
@@ -3,19 +3,19 @@
 /// /!\ Your board needs to use properly configured schema:
 ///`https://github.com/firmata/arduino/blob/main/examples/StandardFirmata/StandardFirmata.ino`
 
-use hermes_five::devices::{Led, Output};
+use hermes_five::devices::Led;
 use hermes_five::hardware::{Board, BoardEvent};
 use hermes_five::io::{RemoteIo, Serial};
-use hermes_five::pause;
+
 
 #[hermes_five::runtime]
 async fn main() {
 
     // Initialize a serial connection with auto-detected port.
-    let board = Board::from(Serial::default()).open();
+    let _board = Board::from(Serial::default()).open();
 
     // Initialize a serial connection with custom port.
-    let board = Board::from(Serial::new("/dev/ttyUSB0")).open();
+    let _board = Board::from(Serial::new("/dev/ttyUSB0")).open();
 
     // Equivalent with full syntax:
     let board = Board::new(RemoteIo::from(Serial::new("/dev/ttyUSB0"))).open();
@@ -23,8 +23,6 @@ async fn main() {
     board.on(BoardEvent::OnReady, |board: Board| async move {
         let mut led = Led::new(&board, 13, false)?;
         led.blink(500);
-        pause!(5000);
-        led.stop();
         Ok(())
     });
 }

--- a/hermes-five/examples/io/remote_wifi.rs
+++ b/hermes-five/examples/io/remote_wifi.rs
@@ -3,16 +3,16 @@
 /// /!\ Your board needs to use properly configured schema:
 ///`https://github.com/firmata/arduino/blob/main/examples/StandardFirmataWiFi/StandardFirmataWiFi.ino`
 
-use hermes_five::devices::{Led, Output};
+use hermes_five::devices::Led;
 use hermes_five::hardware::{Board, BoardEvent};
 use hermes_five::io::{RemoteIo, WiFi};
-use hermes_five::pause;
+
 
 #[hermes_five::runtime]
 async fn main() {
 
     // Initialize a TCP connection with the given IP board.
-    let board = Board::from(WiFi::new("127.0.0.1:3030")).open();
+    let _board = Board::from(WiFi::new("127.0.0.1:3030")).open();
 
     // Equivalent with full syntax:
     let board = Board::new(RemoteIo::from(WiFi::new("127.0.0.1:3030"))).open();
@@ -20,8 +20,6 @@ async fn main() {
     board.on(BoardEvent::OnReady, |board: Board| async move {
         let mut led = Led::new(&board, 2, false)?;
         led.blink(500);
-        pause!(5000);
-        led.stop();
         Ok(())
     });
 }

--- a/hermes-five/examples/led/animate.rs
+++ b/hermes-five/examples/led/animate.rs
@@ -1,5 +1,5 @@
 use hermes_five::animations::Easing;
-use hermes_five::devices::{Led, Output};
+use hermes_five::devices::{Led, OutputDevice};
 use hermes_five::hardware::{Board, BoardEvent};
 use hermes_five::pause;
 

--- a/hermes-five/examples/led/blink.rs
+++ b/hermes-five/examples/led/blink.rs
@@ -1,4 +1,4 @@
-use hermes_five::devices::{Led, Output};
+use hermes_five::devices::{Led, OutputDevice};
 use hermes_five::hardware::{Board, BoardEvent};
 use hermes_five::pause;
 

--- a/hermes-five/examples/led/pulse.rs
+++ b/hermes-five/examples/led/pulse.rs
@@ -1,4 +1,4 @@
-use hermes_five::devices::{Led, Output};
+use hermes_five::devices::{Led, OutputDevice};
 use hermes_five::hardware::{Board, BoardEvent};
 use hermes_five::pause;
 

--- a/hermes-five/examples/servo/animate.rs
+++ b/hermes-five/examples/servo/animate.rs
@@ -1,7 +1,7 @@
 //! Demonstrates how to move a servo in an animated way (control of speed).
 
 use hermes_five::animations::Easing;
-use hermes_five::devices::{Output, Servo};
+use hermes_five::devices::{OutputDevice, Servo};
 use hermes_five::hardware::{Board, BoardEvent};
 use hermes_five::pause;
 

--- a/hermes-five/examples/servo/pca9685.rs
+++ b/hermes-five/examples/servo/pca9685.rs
@@ -1,7 +1,7 @@
 //! Demonstrates how to use and control a servo through a PWM-driver board like the PCA9685.
 //! <https://learn.adafruit.com/16-channel-pwm-servo-driver>
 
-use hermes_five::devices::{Output, Servo};
+use hermes_five::devices::{OutputDevice, Servo};
 use hermes_five::hardware::{Board, BoardEvent, PCA9685};
 use hermes_five::pause;
 

--- a/hermes-five/examples/servo/servo.rs
+++ b/hermes-five/examples/servo/servo.rs
@@ -1,6 +1,6 @@
 //! Demonstrates how to use and control a servo.
 
-use hermes_five::devices::{Output, Servo};
+use hermes_five::devices::{OutputDevice, Servo};
 use hermes_five::hardware::{Board, BoardEvent};
 use hermes_five::pause;
 

--- a/hermes-five/examples/servo/sweep.rs
+++ b/hermes-five/examples/servo/sweep.rs
@@ -1,6 +1,6 @@
 //! This example demonstrates how to loop sweep a servo in a given range of motion.
 
-use hermes_five::devices::{Output, Servo};
+use hermes_five::devices::{OutputDevice, Servo};
 use hermes_five::hardware::{Board, BoardEvent};
 use hermes_five::pause;
 

--- a/hermes-five/src/animations/animation.rs
+++ b/hermes-five/src/animations/animation.rs
@@ -279,7 +279,7 @@ impl Animation {
     /// ```
     /// use hermes_five::hardware::Board;
     /// use hermes_five::hardware::BoardEvent;
-    /// use hermes_five::devices::{Output, Led};
+    /// use hermes_five::devices::{OutputDevice, Led};
     /// use hermes_five::animations::{Animation, AnimationEvent, Easing};
     ///
     /// #[hermes_five::runtime]

--- a/hermes-five/src/animations/keyframe.rs
+++ b/hermes-five/src/animations/keyframe.rs
@@ -4,8 +4,8 @@ use crate::utils::State;
 
 /// Represents a keyframe in an animation sequence.
 ///
-/// A `Keyframe` specifies a target value to be applied to the [`Output`](crate::devices::Output) of the
-/// [`Track`](crate::animations::Track) to which this keyframe belongs. The [`Output`](crate::devices::Output)'s state will be
+/// A `Keyframe` specifies a target value to be applied to the [`OutputDevice`](crate::devices::OutputDevice) of the
+/// [`Track`](crate::animations::Track) to which this keyframe belongs. The [`OutputDevice`](crate::devices::OutputDevice)'s state will be
 /// smoothly transitioned from its current state to the target value during the animation.
 /// This transition occurs between the `start` timestamp and the `end` timestamp.
 ///
@@ -15,7 +15,7 @@ use crate::utils::State;
 /// # Example
 ///
 /// If a `Keyframe` is set with a target value of 100, a start time of 0 ms, and an end time of 1000 ms,
-/// the `Output`'s value will gradually move towards value 100 (whatever it means to it: let it
+/// the `OutputDevice`'s value will gradually move towards value 100 (whatever it means to it: let it
 /// be the brightness of a LED, or the position of a Servo), over 1000 milliseconds, following the
 /// defined easing function.
 /// ```
@@ -25,7 +25,7 @@ use crate::utils::State;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Debug)]
 pub struct Keyframe {
-    /// The target value of the keyframe: will be applied as a state for the [`Output`](crate::devices::Output) of the
+    /// The target value of the keyframe: will be applied as a state for the [`OutputDevice`](crate::devices::OutputDevice) of the
     /// [`Track`] this keyframe belong to.
     target: State,
     /// The start time of the keyframe in milliseconds.

--- a/hermes-five/src/animations/mod.rs
+++ b/hermes-five/src/animations/mod.rs
@@ -3,7 +3,7 @@
 //! This module allows the creation of [`Animation`] made of [`Keyframe`] (state of registered devices) arranged as [`Segment`].
 //!
 //! - An [`Animation`] contains one or more ordered [`Segment`].
-//! - A [`Segment`] contains one or more [`Track`]: one per [`Output`](crate::devices::Output) device to animate.
+//! - A [`Segment`] contains one or more [`Track`]: one per [`OutputDevice`](crate::devices::OutputDevice) device to animate.
 //! - A [`Track`] contains as many [`Keyframe`] as required: they are states that the device must have at a given time.
 //!   The path (succession of intermediate state) taken by the device in between the keyframes is automatically interpolated following an [`Easing`] transition.
 

--- a/hermes-five/src/animations/segment.rs
+++ b/hermes-five/src/animations/segment.rs
@@ -7,7 +7,7 @@ use crate::pause;
 
 /// Represents an [`Animation`](crate::animations::Animation) unit, called a `Segment`.
 ///
-/// A `Segment` is composed of multiple [`Track`](Track)s, each containing sets of [`Keyframe`](Track) associated with an [`Output`](crate::devices::Output).
+/// A `Segment` is composed of multiple [`Track`](Track)s, each containing sets of [`Keyframe`](Track) associated with an [`OutputDevice`](crate::devices::OutputDevice).
 ///
 /// The `Segment` plays the keyframes of its track in a logical and temporal order.
 /// - A segment searches for keyframe to execute and updates the associated devices based on a given

--- a/hermes-five/src/animations/track.rs
+++ b/hermes-five/src/animations/track.rs
@@ -1,11 +1,11 @@
 use std::fmt::{Display, Formatter};
 
 use crate::animations::Keyframe;
-use crate::devices::Output;
+use crate::devices::OutputDevice;
 use crate::errors::Error;
 use crate::utils::{Range, State};
 
-/// Represents an animation track within a [`Segment`](crate::animations::Segment) for a given [`Output`](Output) device.
+/// Represents an animation track within a [`Segment`](crate::animations::Segment) for a given [`OutputDevice`](OutputDevice) device.
 ///
 /// The `Track` struct manages the state and keyframes for an actuator device through a sequence.
 /// It represents the evolution of the device internal state over the sequence (animation) period
@@ -40,9 +40,9 @@ use crate::utils::{Range, State};
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Debug)]
 pub struct Track {
-    /// The [`Output`] device that this track is associated with.
+    /// The [`OutputDevice`] device that this track is associated with.
     /// All keyframes [`Keyframe::target`] values will reference this device.
-    device: Box<dyn Output>,
+    device: Box<dyn OutputDevice>,
     /// The [`Keyframe`]s belonging to this track.
     keyframes: Vec<Keyframe>,
 
@@ -57,7 +57,7 @@ pub struct Track {
 impl Track {
     /// Creates a new `Track` associated with the given actuator.
     #[allow(private_bounds)]
-    pub fn new<T: Output + 'static>(device: T) -> Self {
+    pub fn new<T: OutputDevice + 'static>(device: T) -> Self {
         let history = device.get_state();
         Self {
             device: Box::new(device),
@@ -93,9 +93,7 @@ impl Track {
             Some(keyframe) => {
                 self.update_history(keyframe.get_target());
                 let progress = keyframe.compute_target_coefficient(timeframe.end);
-                let state =
-                    self.device
-                        .scale_state(self.previous.clone(), keyframe.get_target(), progress);
+                let state = self.previous.scale_to(keyframe.get_target(), progress);
                 self.device.set_state(state)?;
             }
         };
@@ -142,7 +140,7 @@ impl Track {
     }
 
     /// Returns the device associated with the [`Track`].
-    pub fn get_device(&self) -> &dyn Output {
+    pub fn get_device(&self) -> &dyn OutputDevice {
         &*self.device
     }
     /// Returns the keyframes of this [`Track`].

--- a/hermes-five/src/devices/mod.rs
+++ b/hermes-five/src/devices/mod.rs
@@ -1,4 +1,4 @@
-//! Defines devices of various [`Input`] / [`Output`] kinds (led, servo, button, sensor, etc.) to be controlled.
+//! Defines devices of various [`Input`] / [`OutputDevice`] kinds (led, servo, button, sensor, etc.) to be controlled.
 
 mod input;
 mod output;
@@ -14,7 +14,7 @@ pub use crate::devices::output::led::Led;
 pub use crate::devices::output::pwm::PwmOutput;
 pub use crate::devices::output::servo::Servo;
 pub use crate::devices::output::servo::ServoType;
-pub use crate::devices::output::Output;
+pub use crate::devices::output::OutputDevice;
 
 use dyn_clone::DynClone;
 use std::fmt::{Debug, Display};

--- a/hermes-five/src/devices/output/digital.rs
+++ b/hermes-five/src/devices/output/digital.rs
@@ -3,14 +3,15 @@ use std::sync::Arc;
 
 use parking_lot::RwLock;
 
-use crate::animations::{Animation, Easing, Keyframe, Track};
-use crate::devices::{Device, Output};
+use crate::animations::Animation;
+use crate::devices::OutputDevice;
 use crate::errors::{Error, HardwareError, StateError};
 use crate::hardware::Hardware;
 use crate::io::{IoProtocol, Pin, PinIdOrName, PinModeId};
+use crate::generate_output_device_boilerplate;
 use crate::utils::State;
 
-/// Represents a digital actuator of unspecified type: an [`Output`] [`Device`] that write digital values
+/// Represents a digital actuator of unspecified type: an [`OutputDevice`] that write digital values
 /// from an OUTPUT compatible pin.
 /// <https://docs.arduino.cc/language-reference/en/functions/digital-io/digitalwrite/>
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -112,6 +113,41 @@ impl DigitalOutput {
     }
 }
 
+generate_output_device_boilerplate!(DigitalOutput);
+impl Output for DigitalOutput {
+    type Value = bool;
+
+    fn parse_state(&self, state: State) -> Result<Self::Value, Error> {
+        match state {
+            State::Boolean(value) => Ok(value),
+            State::Integer(value) => match value {
+                0 => Ok(false),
+                1 => Ok(true),
+                _ => Err(StateError),
+            },
+            _ => Err(StateError),
+        }
+    }
+
+    fn apply_value(&mut self, value: Self::Value) -> Result<(), Error> {
+        match self.get_pin_info()?.mode.id {
+            // on/off digital operation.
+            PinModeId::OUTPUT => self.protocol.digital_write(self.pin, value),
+            id => Err(Error::from(HardwareError::IncompatiblePin {
+                mode: id,
+                pin: self.pin,
+                context: "update digital output",
+            })),
+        }
+    }
+
+    // Expose the required fields
+    fn get_default_value(&self) -> &Self::Value {  &self.default }
+    fn state_lock(&self) -> &RwLock<Self::Value> { &self.state }
+    fn animation_arc(&self) -> &Arc<Option<Animation>> { &self.animation }
+    fn animation_arc_mut(&mut self) -> &mut Arc<Option<Animation>> { &mut self.animation }
+}
+
 impl Display for DigitalOutput {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
@@ -124,76 +160,11 @@ impl Display for DigitalOutput {
     }
 }
 
-#[cfg_attr(feature = "serde", typetag::serde)]
-impl Device for DigitalOutput {}
-
-#[cfg_attr(feature = "serde", typetag::serde)]
-impl Output for DigitalOutput {
-    fn get_state(&self) -> State {
-        (*self.state.read()).into()
-    }
-
-    /// Internal only: you should rather use [`Self::turn_on()`], [`Self::turn_off()`] functions.
-    fn set_state(&mut self, state: State) -> Result<State, Error> {
-        let value = match state {
-            State::Boolean(value) => Ok(value),
-            State::Integer(value) => match value {
-                0 => Ok(false),
-                1 => Ok(true),
-                _ => Err(StateError),
-            },
-            _ => Err(StateError),
-        }?;
-
-        // Early break if no change is required.
-        if *self.state.read() == value {
-            return Ok(value.into());
-        }
-
-        match self.get_pin_info()?.mode.id {
-            // on/off digital operation.
-            PinModeId::OUTPUT => self.protocol.digital_write(self.pin, value),
-            id => Err(Error::from(HardwareError::IncompatiblePin {
-                mode: id,
-                pin: self.pin,
-                context: "update digital output",
-            })),
-        }?;
-        *self.state.write() = value;
-        Ok(value.into())
-    }
-
-    fn get_default(&self) -> State {
-        self.default.into()
-    }
-
-    fn animate<S: Into<State>>(&mut self, state: S, duration: u64, transition: Easing) {
-        self.stop();
-        let mut animation = Animation::from(
-            Track::new(self.clone())
-                .with_keyframe(Keyframe::new(state, 0, duration).set_transition(transition)),
-        );
-        animation.play();
-        self.animation = Arc::new(Some(animation));
-    }
-
-    fn is_busy(&self) -> bool {
-        self.animation.is_some()
-    }
-
-    fn stop(&mut self) {
-        if let Some(animation) = Arc::get_mut(&mut self.animation).and_then(Option::as_mut) {
-            animation.stop();
-        }
-        self.animation = Arc::new(None);
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use crate::animations::Easing;
     use crate::devices::output::digital::DigitalOutput;
-    use crate::devices::Output;
+    use crate::devices::OutputDevice;
     use crate::hardware::Board;
     use crate::io::PinModeId;
     use crate::mocks::MockProtocol;
@@ -279,8 +250,8 @@ mod tests {
                         // Force an incompatible pin mode
         let _ = output
             .protocol
-            .set_pin_mode(output.pin, PinModeId::UNSUPPORTED);
-        assert!(output.set_state(State::Boolean(false)).is_err()); // Should return an error due to incompatible pin mode.
+            .set_pin_mode(output.pin, PinModeId::UNSUPPORTED).is_ok();
+        assert!(output.set_state(State::Boolean(true)).is_err()); // Should return an error due to incompatible pin mode.
     }
 
     #[test]

--- a/hermes-five/src/devices/output/led.rs
+++ b/hermes-five/src/devices/output/led.rs
@@ -479,5 +479,7 @@ mod tests {
         led.blink(200);
         let display_str = format!("{}", led);
         assert_eq!(display_str, "LED (pin=13) [mode=OUTPUT, state=0, default=0, brightness=255, animating=true]");
+
+        led.stop();
     }
 }

--- a/hermes-five/src/devices/output/led.rs
+++ b/hermes-five/src/devices/output/led.rs
@@ -3,12 +3,13 @@ use std::sync::Arc;
 
 use parking_lot::RwLock;
 
-use crate::animations::{Animation, Easing, Keyframe, Segment, Track};
-use crate::devices::{Device, Output};
+use crate::animations::{Animation, Keyframe, Segment, Track};
+use crate::devices::OutputDevice;
 use crate::errors::HardwareError::IncompatiblePin;
 use crate::errors::{Error, StateError};
 use crate::hardware::Hardware;
 use crate::io::{IoProtocol, Pin, PinMode, PinModeId};
+use crate::generate_output_device_boilerplate;
 use crate::utils::{Scalable, State};
 
 /// Represents a LED controlled by a digital pin.
@@ -214,32 +215,12 @@ impl Led {
     }
 }
 
-impl Display for Led {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "LED (pin={}) [state={}, default={}, brightness={}]",
-            self.pin,
-            self.state.read(),
-            self.default,
-            self.brightness
-        )
-    }
-}
-
-#[cfg_attr(feature = "serde", typetag::serde)]
-impl Device for Led {}
-
-#[cfg_attr(feature = "serde", typetag::serde)]
+generate_output_device_boilerplate!(Led);
 impl Output for Led {
-    /// Returns  the actuator current state.
-    fn get_state(&self) -> State {
-        (*self.state.read()).into()
-    }
+    type Value = u16;
 
-    /// Internal only: you should rather use [`Self::turn_on()`], [`Self::turn_off()`], [`Self::set_brightness()`] functions.
-    fn set_state(&mut self, state: State) -> Result<State, Error> {
-        let value = match state {
+    fn parse_state(&self, state: State) -> Result<Self::Value, Error> {
+        match state {
             State::Boolean(value) => match value {
                 true => Ok(self.brightness),
                 false => Ok(0),
@@ -248,13 +229,10 @@ impl Output for Led {
             State::Float(value) => Ok(value as u16),
             State::Signed(value) => Ok(value.max(0) as u16),
             _ => Err(StateError),
-        }?;
-
-        // Early break if no change is required.
-        if *self.state.read() == value {
-            return Ok(value.into());
         }
+    }
 
+    fn apply_value(&mut self, value: Self::Value) -> Result<(), Error> {
         match self.get_pin_info()?.mode.id {
             // on/off digital operation.
             PinModeId::OUTPUT => self.protocol.digital_write(self.pin, value > 0),
@@ -265,38 +243,34 @@ impl Output for Led {
                 pin: self.pin,
                 context: "update LED",
             })),
-        }?;
-        *self.state.write() = value;
-        Ok(value.into())
-    }
-    fn get_default(&self) -> State {
-        self.default.into()
-    }
-
-    fn animate<S: Into<State>>(&mut self, state: S, duration: u64, transition: Easing) {
-        self.stop();
-        let mut animation = Animation::from(
-            Track::new(self.clone())
-                .with_keyframe(Keyframe::new(state, 0, duration).set_transition(transition)),
-        );
-        animation.play();
-        self.animation = Arc::new(Some(animation));
-    }
-
-    fn is_busy(&self) -> bool {
-        self.animation.is_some()
-    }
-
-    fn stop(&mut self) {
-        if let Some(animation) = Arc::get_mut(&mut self.animation).and_then(Option::as_mut) {
-            animation.stop();
         }
-        self.animation = Arc::new(None);
+    }
+
+    // Expose the required fields
+    fn get_default_value(&self) -> &Self::Value {  &self.default }
+    fn state_lock(&self) -> &RwLock<Self::Value> { &self.state }
+    fn animation_arc(&self) -> &Arc<Option<Animation>> { &self.animation }
+    fn animation_arc_mut(&mut self) -> &mut Arc<Option<Animation>> { &mut self.animation }
+}
+
+impl Display for Led {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "LED (pin={}) [mode={}, state={}, default={}, brightness={}, animating={}]",
+            self.pin,
+            self.get_pin_info().map_or("unknown".to_string(), |p| format!("{:?}", p.mode.id)),
+            self.state.read(),
+            self.default,
+            self.brightness,
+            self.is_busy()
+        )
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use crate::animations::Easing;
     use crate::hardware::Board;
     use crate::mocks::MockProtocol;
     use crate::pause;
@@ -366,7 +340,7 @@ mod tests {
 
         // Incorrect pin type.
         let _ = led.protocol.set_pin_mode(led.pin, PinModeId::UNSUPPORTED);
-        assert!(led.set_state(State::Boolean(false)).is_err()); // Should return an error due to incompatible pin mode.
+        assert!(led.set_state(State::Boolean(true)).is_err()); // Should return an error due to incompatible pin mode.
     }
 
     #[test]
@@ -406,7 +380,8 @@ mod tests {
 
     #[test]
     fn test_set_brightness_valid() {
-        let result = _setup_led(8).set_brightness(50);
+        let led = _setup_led(8);
+        let result = led.set_brightness(50);
         assert!(result.is_ok()); // Set brightness to 50%
         let mut led = result.unwrap();
 
@@ -495,10 +470,14 @@ mod tests {
         assert!(!led.is_off());
     }
 
-    #[test]
+    #[hermes_five_macros::test]
     fn test_display_impl() {
-        let led = _setup_led(13);
+        let mut led = _setup_led(13);
         let display_str = format!("{}", led);
-        assert!(display_str.contains("LED (pin=13) [state=0, default=0, brightness=255]"));
+        assert_eq!(display_str, "LED (pin=13) [mode=OUTPUT, state=0, default=0, brightness=255, animating=false]");
+
+        led.blink(200);
+        let display_str = format!("{}", led);
+        assert_eq!(display_str, "LED (pin=13) [mode=OUTPUT, state=0, default=0, brightness=255, animating=true]");
     }
 }

--- a/hermes-five/src/devices/output/mod.rs
+++ b/hermes-five/src/devices/output/mod.rs
@@ -1,7 +1,8 @@
 use crate::animations::Easing;
 use crate::devices::Device;
 use crate::errors::Error;
-use crate::utils::{Scalable, State};
+use crate::utils::State;
+use dyn_clone::DynClone;
 
 pub mod digital;
 pub mod led;
@@ -13,9 +14,10 @@ pub mod servo;
 /// This trait extends [`Device`] and is intended for actuators that requires the same capabilities
 /// as devices, including debugging, cloning, and concurrency support.
 #[cfg_attr(feature = "serde", typetag::serde(tag = "type"))]
-pub trait Output: Device {
+pub trait OutputDevice: Device + DynClone {
     /// Returns  the actuator current state.
     fn get_state(&self) -> State;
+
     /// Internal only: you should use the specific device state modifier functions instead.
     fn set_state(&mut self, state: State) -> Result<State, Error>;
     /// Returns  the actuator default (or neutral) state.
@@ -41,92 +43,119 @@ pub trait Output: Device {
     fn is_busy(&self) -> bool;
     /// Stops the current animation, if any.
     fn stop(&mut self);
-    /// Internal only.
-    fn scale_state(&mut self, previous: State, target: State, progress: f32) -> State {
-        match target {
-            State::Integer(value) => {
-                State::Integer(progress.scale(0, 1, previous.as_integer(), value))
-            }
-            State::Signed(value) => {
-                State::Signed(progress.scale(0, 1, previous.as_signed_integer(), value))
-            }
-            State::Float(value) => State::Float(progress.scale(0, 1, previous.as_float(), value)),
-            _ => match progress {
-                0.0 => previous,
-                _ => target,
-            },
-        }
+
+}
+dyn_clone::clone_trait_object!(OutputDevice);
+
+mod sealed {
+    use crate::animations::Animation;
+    use crate::devices::Device;
+    use crate::errors::Error;
+    use crate::utils::State;
+    use parking_lot::RwLock;
+    use std::sync::Arc;
+
+    pub trait Output: Device + Clone + 'static {
+        /// The specific value the device operates on (e.g., bool, u16).
+        type Value: PartialEq + Copy + Into<State> + Send + Sync;
+
+        /// Parses the generic `State` enum into the device's specific `Value`.
+        fn parse_state(&self, state: State) -> Result<Self::Value, Error>;
+
+        /// Applies the specific `Value` to the hardware.
+        fn apply_value(&mut self, value: Self::Value) -> Result<(), Error>;
+        fn get_default_value(&self) -> &Self::Value;
+        fn state_lock(&self) -> &RwLock<Self::Value>;
+        fn animation_arc(&self) -> &Arc<Option<Animation>>;
+        fn animation_arc_mut(&mut self) -> &mut Arc<Option<Animation>>;
     }
 }
-dyn_clone::clone_trait_object!(Output);
+
+/// Implementation of the `Device` and `OutputDevice` traits for a concrete type implementing `sealed::Output`.
+///
+/// ⚠️ Necessary to work around the current limitation of `typetag`, which does not support
+/// deserialization of generic implementations. This macro preserves the
+/// generic behavior in `sealed::Output` while enabling (de)serialization with `typetag`.
+///
+/// Usage:
+///
+/// ```ignore
+/// use hermes_five::devices::Led;
+/// use hermes_five::generate_output_device_boilerplate;
+///
+/// generate_output_device_boilerplate!(Led);
+/// ```
+///
+/// This generates:
+/// - `impl Device for Led`
+/// - `impl OutputDevice for Led` with full serialization support
+/// - `impl Drop for Led` to drop any ongoing animation
+#[macro_export]
+macro_rules! generate_output_device_boilerplate {
+    ($type:ty) => {
+        use $crate::devices::output::sealed::Output;
+
+        #[cfg_attr(feature = "serde", typetag::serde)]
+        impl $crate::devices::Device for $type {}
+
+        #[cfg_attr(feature = "serde", typetag::serde)]
+        impl $crate::devices::OutputDevice for $type {
+            fn get_state(&self) -> $crate::utils::State {
+                (*self.state_lock().read()).into()
+            }
+
+            fn set_state(&mut self, state: $crate::utils::State) -> Result<$crate::utils::State, $crate::errors::Error> {
+                let value = self.parse_state(state)?;
+
+                if *self.state_lock().read() == value {
+                    return Ok(value.into());
+                }
+
+                self.apply_value(value)?;
+                *self.state_lock().write() = value;
+
+                Ok(value.into())
+            }
+
+            fn get_default(&self) -> $crate::utils::State {
+                (*self.get_default_value()).into()
+            }
+
+            fn animate<S: Into<$crate::utils::State>>(&mut self, state: S, duration: u64, transition: $crate::animations::Easing) {
+                self.stop();
+                let mut animation = $crate::animations::Animation::from(
+                    $crate::animations::Track::new(self.clone())
+                        .with_keyframe($crate::animations::Keyframe::new(state, 0, duration).set_transition(transition)),
+                );
+                animation.play();
+                *self.animation_arc_mut() = std::sync::Arc::new(Some(animation));
+            }
+
+            fn is_busy(&self) -> bool {
+                self.animation_arc().is_some()
+            }
+
+            fn stop(&mut self) {
+                if let Some(animation) = std::sync::Arc::get_mut(self.animation_arc_mut()).and_then(Option::as_mut) {
+                    animation.stop();
+                }
+                *self.animation_arc_mut() = std::sync::Arc::new(None);
+            }
+        }
+
+        impl Drop for $type {
+            fn drop(&mut self) {
+                self.stop(); // Nettoie l'animation si elle est active
+            }
+        }
+    };
+}
 
 #[cfg(test)]
 mod tests {
     use crate::mocks::MockOutputDevice;
 
     use super::*;
-
-    #[test]
-    fn test_scale_state_integer() {
-        let mut device = MockOutputDevice::new(0);
-
-        // Halfway between 10 and 20
-        let result = device.scale_state(State::Integer(10), State::Integer(20), 0.5);
-        assert_eq!(result, State::Integer(15));
-
-        // 75% between 10 and 20
-        let result = device.scale_state(State::Integer(10), State::Integer(20), 0.75);
-        assert_eq!(result, State::Integer(18));
-
-        // 120% between 10 and 20
-        let result = device.scale_state(State::Integer(10), State::Integer(20), 1.2);
-        assert_eq!(result, State::Integer(22));
-    }
-
-    #[test]
-    fn test_scale_state_signed() {
-        let mut device = MockOutputDevice::new(0);
-
-        // Halfway between 10 and 20
-        let result = device.scale_state(State::Signed(-10), State::Signed(10), 0.5);
-        assert_eq!(result, State::Signed(0));
-
-        // 75% between 10 and 20
-        let result = device.scale_state(State::Signed(-10), State::Signed(10), 0.75);
-        assert_eq!(result, State::Signed(5));
-
-        // 120% between 10 and 20
-        let result = device.scale_state(State::Signed(-10), State::Signed(10), 1.2);
-        assert_eq!(result, State::Signed(14));
-    }
-
-    #[test]
-    fn test_scale_state_float() {
-        let mut device = MockOutputDevice::new(0);
-
-        // Halfway between 10 and 20
-        let result = device.scale_state(State::Float(1.0), State::Float(2.0), 0.5);
-        assert_eq!(result, State::Float(1.5));
-
-        // 75% between 10 and 20
-        let result = device.scale_state(State::Float(1.0), State::Float(2.0), 0.75);
-        assert_eq!(result, State::Float(1.75));
-
-        // 120% between 10 and 20
-        let result = device.scale_state(State::Float(1.0), State::Float(2.0), 1.2);
-        assert_eq!(result, State::Float(2.200000047683716));
-    }
-
-    #[test]
-    fn test_scale_state_non_numeric() {
-        let mut device = MockOutputDevice::new(0);
-
-        let result = device.scale_state(State::Boolean(false), State::Boolean(true), 0.0);
-        assert_eq!(result, State::Boolean(false));
-
-        let result = device.scale_state(State::Boolean(false), State::Boolean(true), 0.5);
-        assert_eq!(result, State::Boolean(true));
-    }
 
     #[test]
     fn test_reset() {

--- a/hermes-five/src/devices/output/pwm.rs
+++ b/hermes-five/src/devices/output/pwm.rs
@@ -3,15 +3,17 @@ use std::sync::Arc;
 
 use parking_lot::RwLock;
 
-use crate::animations::{Animation, Easing, Keyframe, Track};
-use crate::devices::{Device, Output};
+use crate::animations::Animation;
+use crate::devices::output::sealed;
+use crate::devices::OutputDevice;
 use crate::errors::HardwareError::IncompatiblePin;
 use crate::errors::{Error, StateError};
 use crate::hardware::Hardware;
 use crate::io::{IoProtocol, Pin, PinIdOrName, PinModeId};
+use crate::generate_output_device_boilerplate;
 use crate::utils::State;
 
-/// Represents an analog actuator of unspecified type: an [`Output`] [`Device`] that write analog values from a PWM compatible pin.
+/// Represents an analog actuator of unspecified type: an [`OutputDevice`] that write analog values from a PWM compatible pin.
 /// <https://docs.arduino.cc/language-reference/en/functions/analog-io/analogWrite/>
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Debug)]
@@ -118,6 +120,42 @@ impl PwmOutput {
     }
 }
 
+generate_output_device_boilerplate!(PwmOutput);
+impl sealed::Output for PwmOutput {
+    type Value = u16;
+
+    fn parse_state(&self, state: State) -> Result<Self::Value, Error> {
+       match state {
+            State::Integer(value) => Ok(value as u16),
+            State::Signed(value) => match value >= 0 {
+                true => Ok(value as u16),
+                false => Err(StateError),
+            },
+            State::Float(value) => match value >= 0.0 {
+                true => Ok(value as u16),
+                false => Err(StateError),
+            },
+            _ => Err(StateError),
+        }
+    }
+
+    fn apply_value(&mut self, value: Self::Value) -> Result<(), Error> {
+        match self.get_pin_info()?.mode.id {
+            PinModeId::PWM => self.protocol.analog_write(self.pin, value),
+            id => Err(Error::from(IncompatiblePin {
+                mode: id,
+                pin: self.pin,
+                context: "update pwm output",
+            })),
+        }
+    }
+
+    fn get_default_value(&self) -> &Self::Value {  &self.default }
+    fn state_lock(&self) -> &RwLock<Self::Value> { &self.state }
+    fn animation_arc(&self) -> &Arc<Option<Animation>> { &self.animation }
+    fn animation_arc_mut(&mut self) -> &mut Arc<Option<Animation>> { &mut self.animation }
+}
+
 impl Display for PwmOutput {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
@@ -131,74 +169,11 @@ impl Display for PwmOutput {
     }
 }
 
-#[cfg_attr(feature = "serde", typetag::serde)]
-impl Device for PwmOutput {}
-
-#[cfg_attr(feature = "serde", typetag::serde)]
-impl Output for PwmOutput {
-    fn get_state(&self) -> State {
-        (*self.state.read()).into()
-    }
-
-    /// Internal only: you should rather use [`Self::set_value()`] function.
-    fn set_state(&mut self, state: State) -> Result<State, Error> {
-        let value = match state {
-            State::Integer(value) => Ok(value as u16),
-            State::Signed(value) => match value >= 0 {
-                true => Ok(value as u16),
-                false => Err(StateError),
-            },
-            State::Float(value) => match value >= 0.0 {
-                true => Ok(value as u16),
-                false => Err(StateError),
-            },
-            _ => Err(StateError),
-        }?;
-
-        // Early break if no change is required.
-        if *self.state.read() == value {
-            return Ok(value.into());
-        }
-
-        match self.get_pin_info()?.mode.id {
-            PinModeId::PWM => self.protocol.analog_write(self.pin, value),
-            id => Err(Error::from(IncompatiblePin {
-                mode: id,
-                pin: self.pin,
-                context: "update pwm output",
-            })),
-        }?;
-        *self.state.write() = value;
-        Ok(value.into())
-    }
-    fn get_default(&self) -> State {
-        self.default.into()
-    }
-    fn animate<S: Into<State>>(&mut self, state: S, duration: u64, transition: Easing) {
-        self.stop();
-        let mut animation = Animation::from(
-            Track::new(self.clone())
-                .with_keyframe(Keyframe::new(state, 0, duration).set_transition(transition)),
-        );
-        animation.play();
-        self.animation = Arc::new(Some(animation));
-    }
-    fn is_busy(&self) -> bool {
-        self.animation.is_some()
-    }
-    fn stop(&mut self) {
-        if let Some(animation) = Arc::get_mut(&mut self.animation).and_then(Option::as_mut) {
-            animation.stop();
-        }
-        self.animation = Arc::new(None);
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use crate::animations::Easing;
     use crate::devices::output::pwm::PwmOutput;
-    use crate::devices::Output;
+    use crate::devices::OutputDevice;
     use crate::hardware::Board;
     use crate::io::PinModeId;
     use crate::mocks::MockProtocol;

--- a/hermes-five/src/devices/output/servo.rs
+++ b/hermes-five/src/devices/output/servo.rs
@@ -4,14 +4,14 @@ use std::time::SystemTime;
 
 use parking_lot::RwLock;
 
-use crate::animations::{Animation, Easing, Keyframe, Segment, Track};
-use crate::devices::{Device, Output};
+use crate::animations::{Animation, Keyframe, Segment, Track};
+use crate::devices::OutputDevice;
 use crate::errors::HardwareError::IncompatiblePin;
 use crate::errors::{Error, StateError};
 use crate::hardware::Hardware;
 use crate::io::{IoProtocol, Pin, PinModeId};
 use crate::utils::{task, Range, Scalable, State};
-use crate::{pause, pause_sync};
+use crate::{generate_output_device_boilerplate, pause, pause_sync};
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Default, Clone, Copy, Debug, PartialEq, Eq)]
@@ -69,9 +69,6 @@ pub struct Servo {
 
     // ########################################
     // # Volatile utility data.
-    /// Last move done by the servo.
-    #[cfg_attr(feature = "serde", serde(skip))]
-    previous: u16,
     #[cfg_attr(feature = "serde", serde(skip))]
     protocol: Box<dyn IoProtocol>,
     /// Inner handler to the task running the animation.
@@ -115,7 +112,6 @@ impl Servo {
             inverted,
             auto_detach: false,
             detach_delay: 20000,
-            previous: u16::MAX, // Ensure previous out-of-range: forces default at start
             protocol: board.get_protocol(),
             animation: Arc::new(None),
             last_move: Arc::new(RwLock::new(None)),
@@ -337,31 +333,11 @@ impl Servo {
     }
 }
 
-impl Display for Servo {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "SERVO (pin={}) [state={}, default={}, range={}-{}]",
-            self.pin,
-            self.state.read(),
-            self.default,
-            self.range.start,
-            self.range.end
-        )
-    }
-}
-
-#[cfg_attr(feature = "serde", typetag::serde)]
-impl Device for Servo {}
-
-#[cfg_attr(feature = "serde", typetag::serde)]
+generate_output_device_boilerplate!(Servo);
 impl Output for Servo {
-    fn get_state(&self) -> State {
-        (*self.state.read()).into()
-    }
-    /// Internal only: you should rather use [`Self::to()`] function.
-    fn set_state(&mut self, state: State) -> Result<State, Error> {
-        // Convert from state.
+    type Value = u16;
+
+    fn parse_state(&self, state: State) -> Result<Self::Value, Error> {
         let value = match state {
             State::Integer(value) => Ok(value as u16),
             State::Signed(value) => match value >= 0 {
@@ -378,10 +354,10 @@ impl Output for Servo {
         // Clamp the request within the Servo range.
         let value: u16 = value.clamp(self.range.start, self.range.end);
 
-        // Early break if no change is required.
-        if *self.state.read() == value {
-            return Ok(value.into());
-        }
+        Ok(value)
+    }
+
+    fn apply_value(&mut self, value: Self::Value) -> Result<(), Error> {
 
         let pwm: f64 = match self.inverted {
             false => value.scale(
@@ -421,40 +397,35 @@ impl Output for Servo {
                     }
                 })?;
             }
-        }
-        let current = *self.state.read();
-        self.previous = current;
-        *self.state.write() = value;
-        Ok(value.into())
-    }
-    fn get_default(&self) -> State {
-        self.default.into()
+        };
+
+        Ok(())
     }
 
-    fn animate<S: Into<State>>(&mut self, state: S, duration: u64, transition: Easing) {
-        self.stop();
-        let mut animation = Animation::from(
-            Track::new(self.clone())
-                .with_keyframe(Keyframe::new(state, 0, duration).set_transition(transition)),
-        );
-        animation.play();
-        self.animation = Arc::new(Some(animation));
-    }
-    fn is_busy(&self) -> bool {
-        self.animation.is_some()
-    }
-    fn stop(&mut self) {
-        if let Some(animation) = Arc::get_mut(&mut self.animation).and_then(Option::as_mut) {
-            animation.stop();
-        }
-        self.animation = Arc::new(None);
+    // Expose the required fields
+    fn get_default_value(&self) -> &Self::Value {  &self.default }
+    fn state_lock(&self) -> &RwLock<Self::Value> { &self.state }
+    fn animation_arc(&self) -> &Arc<Option<Animation>> { &self.animation }
+    fn animation_arc_mut(&mut self) -> &mut Arc<Option<Animation>> { &mut self.animation }
+}
+impl Display for Servo {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "SERVO (pin={}) [state={}, default={}, range={}-{}]",
+            self.pin,
+            self.state.read(),
+            self.default,
+            self.range.start,
+            self.range.end
+        )
     }
 }
 
 #[cfg(test)]
 mod tests {
     use crate::animations::Easing;
-    use crate::devices::{Output, Servo};
+    use crate::devices::{OutputDevice, Servo};
     use crate::hardware::Board;
     use crate::io::PinModeId;
     use crate::mocks::MockProtocol;
@@ -543,7 +514,7 @@ mod tests {
         assert!(servo.is_auto_detach());
 
         // Moving should auto-reattach.
-        servo.to(180).expect("");
+        servo.to(90).expect("");
         assert_eq!(servo.get_pin_info().unwrap().mode.id, PinModeId::SERVO);
         pause!(80);
         // Continue moving should reset detach timer

--- a/hermes-five/src/lib.rs
+++ b/hermes-five/src/lib.rs
@@ -19,7 +19,7 @@
 //!
 //! - Define remotely controllable [`Board`](hardware::Board) (Arduino currently)
 //! - Control boards though an [`IoProtocol`](io::IoProtocol) connection ([`Serial`](io::Serial) for the moment)
-//! - Remote control all types of [`Device`](devices::Device)s such as [`Output`](devices::Output)s (LED, servo, etc.) or [`Input`](devices::Input)s (button, switch, sensors,
+//! - Remote control all types of [`Device`](devices::Device)s such as [`OutputDevice`](devices::OutputDevice)s (LED, servo, etc.) or [`Input`](devices::Input)s (button, switch, sensors,
 //! - etc.) individually
 //! - Create and play [`Animation`](animations::Animation) with auto-interpolate movements
 //!

--- a/hermes-five/src/mocks/output_device.rs
+++ b/hermes-five/src/mocks/output_device.rs
@@ -4,11 +4,11 @@ use std::sync::Arc;
 use parking_lot::RwLock;
 
 use crate::animations::Easing;
-use crate::devices::{Device, Output};
+use crate::devices::{Device, OutputDevice};
 use crate::errors::Error;
 use crate::utils::State;
 
-/// Mock [`Output`] for testing purposes.
+/// Mock [`OutputDevice`] for testing purposes.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Debug)]
 pub struct MockOutputDevice {
@@ -40,7 +40,7 @@ impl Display for MockOutputDevice {
 impl Device for MockOutputDevice {}
 
 #[cfg_attr(feature = "serde", typetag::serde)]
-impl Output for MockOutputDevice {
+impl OutputDevice for MockOutputDevice {
     fn get_state(&self) -> State {
         self.state.into()
     }

--- a/hermes-five/src/utils/state.rs
+++ b/hermes-five/src/utils/state.rs
@@ -1,3 +1,4 @@
+use crate::utils::Scalable;
 use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
 
@@ -199,6 +200,23 @@ impl State {
             _ => HashMap::<String, State>::default(),
         }
     }
+
+    /// Return the intermediate state from self to target at a given progress (between 0 and 1).
+    pub fn scale_to(&self, target: State, progress: f32) -> State {
+        match target {
+            State::Integer(value) => {
+                State::Integer(progress.scale(0, 1, self.as_integer(), value))
+            }
+            State::Signed(value) => {
+                State::Signed(progress.scale(0, 1, self.as_signed_integer(), value))
+            }
+            State::Float(value) => State::Float(progress.scale(0, 1, self.as_float(), value)),
+            _ => match progress {
+                0.0 => self.clone(),
+                _ => target,
+            },
+        }
+    }
 }
 
 // **********************************************
@@ -254,9 +272,8 @@ impl<T: Into<State>> FromIterator<T> for State {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
-
     use super::*;
+    use std::collections::HashMap;
 
     #[test]
     fn test_as_boolean() {
@@ -474,6 +491,60 @@ mod tests {
             state,
             State::Array(vec![State::Signed(1), State::Signed(2)])
         );
+    }
+
+    #[test]
+    fn test_scale_to_integer() {
+        // Halfway between 10 and 20
+        let result = State::Integer(10).scale_to(State::Integer(20), 0.5);
+        assert_eq!(result, State::Integer(15));
+
+        // 75% between 10 and 20
+        let result = State::Integer(10).scale_to(State::Integer(20), 0.75);
+        assert_eq!(result, State::Integer(18));
+
+        // 120% between 10 and 20
+        let result = State::Integer(10).scale_to(State::Integer(20), 1.2);
+        assert_eq!(result, State::Integer(22));
+    }
+
+    #[test]
+    fn test_scale_to_signed() {
+        // Halfway between 10 and 20
+        let result = State::Signed(-10).scale_to(State::Signed(10), 0.5);
+        assert_eq!(result, State::Signed(0));
+
+        // 75% between 10 and 20
+        let result = State::Signed(-10).scale_to(State::Signed(10), 0.75);
+        assert_eq!(result, State::Signed(5));
+
+        // 120% between 10 and 20
+        let result = State::Signed(-10).scale_to(State::Signed(10), 1.2);
+        assert_eq!(result, State::Signed(14));
+    }
+
+    #[test]
+    fn test_scale_to_float() {
+        // Halfway between 10 and 20
+        let result = State::Float(1.0).scale_to(State::Float(2.0), 0.5);
+        assert_eq!(result, State::Float(1.5));
+
+        // 75% between 10 and 20
+        let result = State::Float(1.0).scale_to(State::Float(2.0), 0.75);
+        assert_eq!(result, State::Float(1.75));
+
+        // 120% between 10 and 20
+        let result = State::Float(1.0).scale_to(State::Float(2.0), 1.2);
+        assert_eq!(result, State::Float(2.200000047683716));
+    }
+
+    #[test]
+    fn test_scale_to_non_numeric() {
+        let result = State::Boolean(false).scale_to(State::Boolean(true), 0.0);
+        assert_eq!(result, State::Boolean(false));
+
+        let result = State::Boolean(false).scale_to(State::Boolean(true), 0.5);
+        assert_eq!(result, State::Boolean(true));
     }
 
     #[test]


### PR DESCRIPTION
Implements task #14 

**Summary:**
This PR addresses the design issues described in #14 by introducing a sealed `Output` trait to encapsulate shared logic across all output devices. The goal is to reduce boilerplate and improve maintainability as the number of device implementations increases.

**Motivation:**
Currently, any structural change to output behavior must be replicated manually across every output device implementation. This results in code duplication and fragility, which scales poorly with new devices.

**Changes Introduced:**
- Renamed the existing `Output` trait to `OutputDevice` for better semantic clarity.
- Introduced a sealed `Output` trait containing shared boilerplate logic.
- Updated all device implementations to implement both `Output` (sealed) and `OutputDevice`.
- Designed this abstraction to centralize shared logic while preserving the freedom of device-specific customization.

**API Impact:**
Breaking change: All output devices must now implement both `Output` and `OutputDevice`.
A macro has been introduced to ease migration and reduce verbosity for implementers.

