### PR TITLE
Task/issue 17  event type check

### DIFF
--- a/docs/guide/introduction/concepts.md
+++ b/docs/guide/introduction/concepts.md
@@ -98,7 +98,6 @@ async fn main() {  // [!code focus]
   let board = Board::run();
   board.on(BoardEvent::OnReady, |board: Board| async move {
     // Do something here !
-    Ok(())
   });
 }  // [!code focus]
 ```
@@ -116,7 +115,6 @@ async fn main() {
   let board = Board::run(); // [!code focus]
   board.on(BoardEvent::OnReady, |board: Board| async move {
     // Do something here !
-    Ok(())
   });
 }
 ```
@@ -136,7 +134,6 @@ async fn main() {
   let board = Board::run();
   board.on(BoardEvent::OnReady, |board: Board| async move { // [!code focus]
     // Do something here ! // [!code focus]
-    Ok(()) // [!code focus]
   });
 }
 ```

--- a/docs/guide/introduction/troubleshooting.md
+++ b/docs/guide/introduction/troubleshooting.md
@@ -58,7 +58,6 @@ async fn main() {
     let board = Board::run();
     board.on(BoardEvent::OnReady, |mut board: Board| async move {
         println!("Pins {:#?}", board.get_io().read().pins);
-        Ok(())
     });
 }
 ```

--- a/hermes-five/examples/advanced/gamepad/src/main.rs
+++ b/hermes-five/examples/advanced/gamepad/src/main.rs
@@ -103,5 +103,8 @@ async fn main() {
             // Pause
             pause!(UPDATE_INTERVAL_MS);
         }
+
+        #[allow(unreachable_code)]
+        Ok(())
     });
 }

--- a/hermes-five/examples/animation/animation.rs
+++ b/hermes-five/examples/animation/animation.rs
@@ -9,7 +9,7 @@ async fn main() {
     let board = Board::run();
 
     board.on(BoardEvent::OnReady, |board: Board| async move {
-        let servo = Servo::new(&board, 22, 0).unwrap();
+        let servo = Servo::new(&board, 22, 0)?;
 
         // This is the full animation declaration:
         // - an `Animation` contains:

--- a/hermes-five/examples/animation/multiple_animations.rs
+++ b/hermes-five/examples/animation/multiple_animations.rs
@@ -8,11 +8,10 @@ async fn main() {
     let board = Board::run();
 
     board.on(BoardEvent::OnReady, |board: Board| async move {
-        let servo = Servo::new(&board, 9, 0).unwrap();
+        let servo = Servo::new(&board, 9, 0)?;
         let led = Led::new(&board, 11, false)
             .unwrap()
-            .set_brightness(100)
-            .unwrap();
+            .set_brightness(100)?;
 
         let mut animation_servo = Animation::from(
             Segment::from(

--- a/hermes-five/examples/board/creation.rs
+++ b/hermes-five/examples/board/creation.rs
@@ -22,7 +22,6 @@ async fn main() {
     // Find more about this in the 'examples/board/creation.rs' example.
     board.on(BoardEvent::OnReady, |_: Board| async move {
         // Do something here !
-        Ok(())
     });
 
     // ----

--- a/hermes-five/examples/board/events.rs
+++ b/hermes-five/examples/board/events.rs
@@ -11,7 +11,6 @@
 //! - You can register multiple callbacks for a same event.
 //! - Callbacks are asynchronous futures, hence the `async move` syntax.
 //! - Callbacks follows a strict syntax and MUST be used with the proper argument signature.
-//! - All callbacks MUST return `Result<(), Error>>`.
 
 use hermes_five::hardware::{Board, BoardEvent};
 
@@ -25,17 +24,14 @@ async fn main() {
     board.on(BoardEvent::OnReady, |board: Board| async move {
         println!("Connection done on board.");
         board.close();
-        Ok(())
     });
 
     board.on(BoardEvent::OnClose, |_: Board| async move {
         println!("Connection closed on board.");
-        Ok(())
     });
 
     // Note that you can register as many event handlers as you want on a same event.
     board.on(BoardEvent::OnReady, |_: Board| async move {
         println!("Hello from another event handler!");
-        Ok(())
     });
 }

--- a/hermes-five/examples/button/inverted.rs
+++ b/hermes-five/examples/button/inverted.rs
@@ -15,11 +15,11 @@ async fn main() {
             println!("Inverted button value changed: {}", value);
             Ok(())
         });
-        button_inverted.on(InputEvent::OnPress, |_: ()| async move {
+        button_inverted.on(InputEvent::OnPress, |_: bool| async move {
             println!("Inverted button pressed");
             Ok(())
         });
-        button_inverted.on(InputEvent::OnRelease, |_: ()| async move {
+        button_inverted.on(InputEvent::OnRelease, |_: bool| async move {
             println!("Inverted button released");
             Ok(())
         });
@@ -29,11 +29,11 @@ async fn main() {
             println!("Inverted pullup button value changed: {}", value);
             Ok(())
         });
-        pullup_button_inverted.on(InputEvent::OnPress, |_: ()| async move {
+        pullup_button_inverted.on(InputEvent::OnPress, |_: bool| async move {
             println!("Inverted pullup button pressed");
             Ok(())
         });
-        pullup_button_inverted.on(InputEvent::OnRelease, |_: ()| async move {
+        pullup_button_inverted.on(InputEvent::OnRelease, |_: bool| async move {
             println!("Inverted pullup button released");
             Ok(())
         });

--- a/hermes-five/examples/button/inverted.rs
+++ b/hermes-five/examples/button/inverted.rs
@@ -13,30 +13,25 @@ async fn main() {
 
         button_inverted.on(InputEvent::OnChange, |value: bool| async move {
             println!("Inverted button value changed: {}", value);
-            Ok(())
         });
         button_inverted.on(InputEvent::OnPress, |_: bool| async move {
             println!("Inverted button pressed");
-            Ok(())
         });
         button_inverted.on(InputEvent::OnRelease, |_: bool| async move {
             println!("Inverted button released");
-            Ok(())
         });
 
         let pullup_button_inverted = Button::new_inverted_pullup(&board, 8)?;
         pullup_button_inverted.on(InputEvent::OnChange, |value: bool| async move {
             println!("Inverted pullup button value changed: {}", value);
-            Ok(())
         });
         pullup_button_inverted.on(InputEvent::OnPress, |_: bool| async move {
             println!("Inverted pullup button pressed");
-            Ok(())
         });
         pullup_button_inverted.on(InputEvent::OnRelease, |_: bool| async move {
             println!("Inverted pullup button released");
-            Ok(())
         });
+
         Ok(())
     });
 }

--- a/hermes-five/examples/button/pullup.rs
+++ b/hermes-five/examples/button/pullup.rs
@@ -15,19 +15,16 @@ async fn main() {
         // Triggered function when the button state changes.
         button.on(InputEvent::OnChange, |value: bool| async move {
             println!("Push button value changed: {}", value);
-            Ok(())
         });
 
         // Triggered function when the button is pressed.
         button.on(InputEvent::OnPress, |_: bool| async move {
             println!("Push button pressed");
-            Ok(())
         });
 
         // Triggered function when the button is released.
         button.on(InputEvent::OnRelease, |_: bool| async move {
             println!("Push button released");
-            Ok(())
         });
 
         Ok(())

--- a/hermes-five/examples/button/pullup.rs
+++ b/hermes-five/examples/button/pullup.rs
@@ -19,13 +19,13 @@ async fn main() {
         });
 
         // Triggered function when the button is pressed.
-        button.on(InputEvent::OnPress, |_: ()| async move {
+        button.on(InputEvent::OnPress, |_: bool| async move {
             println!("Push button pressed");
             Ok(())
         });
 
         // Triggered function when the button is released.
-        button.on(InputEvent::OnRelease, |_: ()| async move {
+        button.on(InputEvent::OnRelease, |_: bool| async move {
             println!("Push button released");
             Ok(())
         });

--- a/hermes-five/examples/button/simple.rs
+++ b/hermes-five/examples/button/simple.rs
@@ -15,19 +15,16 @@ async fn main() {
         // Triggered function when the button state changes.
         button.on(InputEvent::OnChange, |value: bool| async move {
             println!("Push button value changed: {}", value);
-            Ok(())
         });
 
         // Triggered function when the button is pressed.
         button.on(InputEvent::OnPress, |_: bool| async move {
             println!("Push button pressed");
-            Ok(())
         });
 
         // Triggered function when the button is released.
         button.on(InputEvent::OnRelease, |_: bool| async move {
             println!("Push button released");
-            Ok(())
         });
 
         Ok(())

--- a/hermes-five/examples/button/simple.rs
+++ b/hermes-five/examples/button/simple.rs
@@ -19,13 +19,13 @@ async fn main() {
         });
 
         // Triggered function when the button is pressed.
-        button.on(InputEvent::OnPress, |_: ()| async move {
+        button.on(InputEvent::OnPress, |_: bool| async move {
             println!("Push button pressed");
             Ok(())
         });
 
         // Triggered function when the button is released.
-        button.on(InputEvent::OnRelease, |_: ()| async move {
+        button.on(InputEvent::OnRelease, |_: bool| async move {
             println!("Push button released");
             Ok(())
         });

--- a/hermes-five/examples/led/pulse.rs
+++ b/hermes-five/examples/led/pulse.rs
@@ -8,7 +8,7 @@ async fn main() {
 
     board.on(BoardEvent::OnReady, |board: Board| async move {
         // Register a LED on pin 13 (default arduino led).
-        let mut led = Led::new(&board, 8, false).expect("Embedded led is instantiated");
+        let mut led = Led::new(&board, 8, false)?;
 
         // Pulse the LED every 500ms.
         led.pulse(500);

--- a/hermes-five/examples/sensors/microwave.rs
+++ b/hermes-five/examples/sensors/microwave.rs
@@ -15,19 +15,16 @@ async fn main() {
         // Triggered function when the sensor state changes.
         sensor.on(InputEvent::OnChange, |value: bool| async move {
             println!("Sensor value changed: {}", value);
-            Ok(())
         });
 
         // Triggered function when the sensor state changes to high.
         sensor.on(InputEvent::OnHigh, |_: bool| async move {
             println!("Moving object detected");
-            Ok(())
         });
 
         // Triggered function when the sensor state changes to low.
         sensor.on(InputEvent::OnLow, |_: bool| async move {
             println!("Moving object detection lost");
-            Ok(())
         });
 
         Ok(())

--- a/hermes-five/examples/sensors/microwave.rs
+++ b/hermes-five/examples/sensors/microwave.rs
@@ -19,13 +19,13 @@ async fn main() {
         });
 
         // Triggered function when the sensor state changes to high.
-        sensor.on(InputEvent::OnHigh, |_: ()| async move {
+        sensor.on(InputEvent::OnHigh, |_: bool| async move {
             println!("Moving object detected");
             Ok(())
         });
 
         // Triggered function when the sensor state changes to low.
-        sensor.on(InputEvent::OnLow, |_: ()| async move {
+        sensor.on(InputEvent::OnLow, |_: bool| async move {
             println!("Moving object detection lost");
             Ok(())
         });

--- a/hermes-five/examples/sensors/potentiometer.rs
+++ b/hermes-five/examples/sensors/potentiometer.rs
@@ -15,7 +15,6 @@ async fn main() {
         // Triggered function when the sensor state changes.
         potentiometer.on(InputEvent::OnChange, |value: u16| async move {
             println!("Sensor value changed: {}", value);
-            Ok(())
         });
 
         Ok(())

--- a/hermes-five/src/animations/animation.rs
+++ b/hermes-five/src/animations/animation.rs
@@ -1,14 +1,13 @@
+use parking_lot::RwLock;
 use std::fmt::{Display, Formatter};
 
-use parking_lot::RwLock;
-
-use crate::errors::Error;
-use crate::utils::{task, EventHandler, EventManager, TaskHandler};
+use crate::utils::{task, EventManager, TaskHandler};
 
 use crate::animations::{Segment, Track};
 use std::sync::Arc;
 
-/// Lists all events a Animation can emit/listen.
+/// Lists all events an Animation can emit/listen.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum AnimationEvent {
     /// Triggered when the animation starts.
     OnSegmentDone,
@@ -87,7 +86,7 @@ pub struct Animation {
     interval: Arc<RwLock<Option<TaskHandler>>>,
     /// The event manager for the animation.
     #[cfg_attr(feature = "serde", serde(skip))]
-    events: EventManager,
+    events: EventManager<AnimationEvent, Animation>,
 }
 
 // ########################################
@@ -98,7 +97,7 @@ impl Default for Animation {
             segments: vec![],
             current: Arc::new(RwLock::new(0)),
             interval: Arc::new(RwLock::new(None)),
-            events: Default::default(),
+            events: EventManager::default(),
         }
     }
 }
@@ -108,12 +107,11 @@ impl Animation {
     ///
     /// The animation will start from the current segment or from the beginning if it was stopped.
     pub fn play(&mut self) -> &mut Self {
-        let events_clone = self.events.clone();
         let mut self_clone = self.clone();
 
         self.events.emit(AnimationEvent::OnStart, self.clone());
         if self.get_duration() > 0 {
-            let handler = task::run(async move {
+            let handler = match task::run(async move {
                 // Loop through the segments and run them one by one.
                 for index in self_clone.get_current()..self_clone.segments.len() {
                     *self_clone.current.write() = index;
@@ -121,15 +119,24 @@ impl Animation {
                     // Retrieve the currently running segment.
                     let segment_playing = self_clone.segments.get_mut(index).unwrap();
                     segment_playing.play().await?;
-                    events_clone.emit(AnimationEvent::OnSegmentDone, segment_playing.clone());
+                    self_clone
+                        .events
+                        .emit(AnimationEvent::OnSegmentDone, self_clone.clone());
                 }
 
                 *self_clone.current.write() = 0; // reset to the beginning
                 *self_clone.interval.write() = None;
-                events_clone.emit(AnimationEvent::OnComplete, self_clone);
+                self_clone
+                    .events
+                    .emit(AnimationEvent::OnComplete, self_clone.clone());
                 Ok(())
-            })
-            .unwrap();
+            }) {
+                Ok(handler) => handler,
+                Err(e) => {
+                    println!("task::run failed: {:?}", e);
+                    return self;
+                }
+            };
             *self.interval.write() = Some(handler);
         }
 
@@ -302,14 +309,12 @@ impl Animation {
     ///     });
     /// }
     /// ```
-    pub fn on<S, F, T, Fut>(&self, event: S, callback: F) -> EventHandler
+    pub fn on<F, Fut>(&self, event: AnimationEvent, handler: F)
     where
-        S: Into<String>,
-        T: 'static + Send + Sync + Clone,
-        F: FnMut(T) -> Fut + Send + 'static,
-        Fut: std::future::Future<Output = Result<(), Error>> + Send + 'static,
+        F: Fn(Animation) -> Fut + Send + Sync + 'static,
+        Fut: std::future::Future<Output = crate::utils::Result<()>> + Send + 'static,
     {
-        self.events.on(event, callback)
+        self.events.on(event, handler);
     }
 }
 
@@ -462,7 +467,7 @@ mod tests {
         });
 
         let moved_active_segment = active_segment.clone();
-        animation.on(AnimationEvent::OnSegmentDone, move |_: Segment| {
+        animation.on(AnimationEvent::OnSegmentDone, move |_: Animation| {
             let captured_active_segment = moved_active_segment.clone();
             async move {
                 let index = captured_active_segment.load(Ordering::SeqCst) + 1;

--- a/hermes-five/src/animations/animation.rs
+++ b/hermes-five/src/animations/animation.rs
@@ -1,7 +1,7 @@
 use parking_lot::RwLock;
 use std::fmt::{Display, Formatter};
-
-use crate::utils::{task, EventManager, TaskHandler};
+use std::future::Future;
+use crate::utils::{task, EventManager, GenericResult, TaskHandler};
 
 use crate::animations::{Segment, Track};
 use std::sync::Arc;
@@ -49,7 +49,7 @@ impl From<AnimationEvent> for String {
 /// async fn main() {
 ///     let board = Board::run();
 ///     board.on(BoardEvent::OnReady, |board: Board| async move {
-///         let servo = Servo::new(&board, 9, 0).unwrap();
+///         let servo = Servo::new(&board, 9, 0)?;
 ///
 ///         let mut animation = Animation::from(
 ///             Segment::from(
@@ -299,20 +299,19 @@ impl Animation {
     ///
     ///         animation.on(AnimationEvent::OnStart, |_: Animation| async move {
     ///             println!("Animation has started");
-    ///             Ok(())
     ///         });
     ///         animation.on(AnimationEvent::OnComplete, |_: Animation| async move {
     ///             println!("Animation done");
-    ///             Ok(())
     ///         });
     ///         Ok(())
     ///     });
     /// }
     /// ```
-    pub fn on<F, Fut>(&self, event: AnimationEvent, handler: F)
+    pub fn on<F, Fut, R>(&self, event: AnimationEvent, handler: F)
     where
         F: Fn(Animation) -> Fut + Send + Sync + 'static,
-        Fut: std::future::Future<Output = crate::utils::Result<()>> + Send + 'static,
+        Fut: Future<Output = R> + Send + 'static,
+        R: Into<GenericResult>
     {
         self.events.on(event, handler);
     }
@@ -462,7 +461,6 @@ mod tests {
             async move {
                 captured_flag.store(true, Ordering::SeqCst);
                 assert_eq!(animation.get_current(), 0);
-                Ok(())
             }
         });
 
@@ -472,7 +470,6 @@ mod tests {
             async move {
                 let index = captured_active_segment.load(Ordering::SeqCst) + 1;
                 captured_active_segment.store(index, Ordering::SeqCst);
-                Ok(())
             }
         });
 
@@ -482,7 +479,6 @@ mod tests {
             async move {
                 captured_flag.store(false, Ordering::SeqCst);
                 assert_eq!(animation.get_current(), 5);
-                Ok(())
             }
         });
 

--- a/hermes-five/src/devices/input/analog.rs
+++ b/hermes-five/src/devices/input/analog.rs
@@ -9,8 +9,8 @@ use crate::errors::Error;
 use crate::hardware::Hardware;
 use crate::io::{IoProtocol, PinIdOrName, PinModeId};
 use crate::pause;
-use crate::utils::task;
-use crate::utils::{EventHandler, EventManager, State, TaskHandler};
+use crate::utils::{task, EventManager};
+use crate::utils::{State, TaskHandler};
 
 /// Represents an analog sensor of unspecified type: an [`Input`] [`Device`] that reads analog values
 /// from an ANALOG compatible pin.
@@ -35,7 +35,7 @@ pub struct AnalogInput {
     handler: Arc<RwLock<Option<TaskHandler>>>,
     /// The event manager for the AnalogInput.
     #[cfg_attr(feature = "serde", serde(skip))]
-    events: EventManager,
+    events: EventManager<InputEvent, u16>,
 }
 
 impl AnalogInput {
@@ -157,14 +157,12 @@ impl AnalogInput {
     ///     });
     /// }
     /// ```
-    pub fn on<S, F, T, Fut>(&self, event: S, callback: F) -> EventHandler
+    pub fn on<F, Fut>(&self, event: InputEvent, handler: F)
     where
-        S: Into<String>,
-        T: 'static + Send + Sync + Clone,
-        F: FnMut(T) -> Fut + Send + 'static,
-        Fut: std::future::Future<Output = Result<(), Error>> + Send + 'static,
+        F: Fn(u16) -> Fut + Send + Sync + 'static,
+        Fut: std::future::Future<Output = crate::utils::Result<()>> + Send + 'static,
     {
-        self.events.on(event, callback)
+        self.events.on(event, handler);
     }
 }
 

--- a/hermes-five/src/devices/input/analog.rs
+++ b/hermes-five/src/devices/input/analog.rs
@@ -1,4 +1,5 @@
 use std::fmt::{Display, Formatter};
+use std::future::Future;
 use std::sync::Arc;
 
 use parking_lot::RwLock;
@@ -9,7 +10,7 @@ use crate::errors::Error;
 use crate::hardware::Hardware;
 use crate::io::{IoProtocol, PinIdOrName, PinModeId};
 use crate::pause;
-use crate::utils::{task, EventManager};
+use crate::utils::{task, EventManager, GenericResult};
 use crate::utils::{State, TaskHandler};
 
 /// Represents an analog sensor of unspecified type: an [`Input`] [`Device`] that reads analog values
@@ -141,7 +142,6 @@ impl AnalogInput {
     ///         // Triggered function when the sensor state changes.
     ///         potentiometer.on(InputEvent::OnChange, |value: u16| async move {
     ///             println!("Sensor value changed: {}", value);
-    ///             Ok(())
     ///         });
     ///
     ///         // The above code will run forever.
@@ -157,10 +157,11 @@ impl AnalogInput {
     ///     });
     /// }
     /// ```
-    pub fn on<F, Fut>(&self, event: InputEvent, handler: F)
+    pub fn on<F, Fut, R>(&self, event: InputEvent, handler: F)
     where
         F: Fn(u16) -> Fut + Send + Sync + 'static,
-        Fut: std::future::Future<Output = crate::utils::Result<()>> + Send + 'static,
+        Fut: Future<Output = R> + Send + 'static,
+        R: Into<GenericResult>
     {
         self.events.on(event, handler);
     }
@@ -244,7 +245,6 @@ mod tests {
             let captured_flag = moved_change_flag.clone();
             async move {
                 captured_flag.store(new_state, Ordering::SeqCst);
-                Ok(())
             }
         });
 

--- a/hermes-five/src/devices/input/button.rs
+++ b/hermes-five/src/devices/input/button.rs
@@ -8,7 +8,7 @@ use crate::errors::Error;
 use crate::hardware::Hardware;
 use crate::io::{IoProtocol, PinIdOrName, PinModeId};
 use crate::pause;
-use crate::utils::{task, EventHandler, EventManager, State, TaskHandler};
+use crate::utils::{task, EventManager, State, TaskHandler};
 
 /// Represents a simple push button as an input of the board.
 /// <https://docs.arduino.cc/built-in-examples/digital/Button>
@@ -40,10 +40,11 @@ pub struct Button {
     handler: Arc<RwLock<Option<TaskHandler>>>,
     /// The event manager for the button.
     #[cfg_attr(feature = "serde", serde(skip))]
-    events: EventManager,
+    events: EventManager<InputEvent, bool>,
 }
 
 impl Button {
+
     /// Creates an instance of a PULL-DOWN button attached to a given board:
     /// <https://docs.arduino.cc/built-in-examples/digital/Button/>
     ///
@@ -61,7 +62,7 @@ impl Button {
             pullup: false,
             protocol: board.get_protocol(),
             handler: Arc::new(RwLock::new(None)),
-            events: Default::default(),
+            events: EventManager::<InputEvent, bool>::default(),
         }
         .start_with(board, pin)
     }
@@ -84,7 +85,7 @@ impl Button {
             pullup: false,
             protocol: board.get_protocol(),
             handler: Arc::new(RwLock::new(None)),
-            events: Default::default(),
+            events: EventManager::default(),
         }
         .start_with(board, pin)
     }
@@ -106,7 +107,7 @@ impl Button {
             pullup: true,
             protocol: board.get_protocol(),
             handler: Arc::new(RwLock::new(None)),
-            events: Default::default(),
+            events: EventManager::default(),
         }
         .start_with(board, pin)
     }
@@ -133,7 +134,7 @@ impl Button {
             pullup: true,
             protocol: board.get_protocol(),
             handler: Arc::new(RwLock::new(None)),
-            events: Default::default(),
+            events: EventManager::default(),
         }
         .start_with(board, pin)
     }
@@ -218,12 +219,12 @@ impl Button {
 
                             match self_clone.pullup {
                                 true => match pin_value {
-                                    true => self_clone.events.emit(InputEvent::OnRelease, ()),
-                                    false => self_clone.events.emit(InputEvent::OnPress, ()),
+                                    true => self_clone.events.emit(InputEvent::OnRelease, pin_value),
+                                    false => self_clone.events.emit(InputEvent::OnPress, pin_value),
                                 },
                                 false => match pin_value {
-                                    true => self_clone.events.emit(InputEvent::OnPress, ()),
-                                    false => self_clone.events.emit(InputEvent::OnRelease, ()),
+                                    true => self_clone.events.emit(InputEvent::OnPress, pin_value),
+                                    false => self_clone.events.emit(InputEvent::OnRelease, pin_value),
                                 },
                             };
                         }
@@ -254,9 +255,9 @@ impl Button {
     /// - **`InputEvent::OnChange` | `change`:** Triggered when the button value changes.    
     ///   _The callback must receive the following parameter: `|value: u16| { ... }`_
     /// - **`InputEvent::OnRelease` | `released`:** Triggered when the button value changes.     
-    ///   _The callback must receive the void parameter: `|_:()| { ... }`_
+    ///   _The callback must receive the void parameter: `|value: u16| { ... }`_
     /// - **`InputEvent::OnPress` | `pressed`:** Triggered when the button value changes.     
-    ///   _The callback must receive the void parameter: `|_:()| { ... }`_
+    ///   _The callback must receive the void parameter: `|value: u16| { ... }`_
     ///
     /// # Example
     ///
@@ -272,7 +273,7 @@ impl Button {
     ///         // Register a Button on pin 2.
     ///         let button = Button::new(&board, 2)?;
     ///         // Triggered function when the button is pressed.
-    ///         button.on(InputEvent::OnPress, |_: ()| async move {
+    ///         button.on(InputEvent::OnPress, |_: bool| async move {
     ///             println!("Push button pressed");
     ///             Ok(())
     ///         });
@@ -290,14 +291,12 @@ impl Button {
     ///     });
     /// }
     /// ```
-    pub fn on<S, F, T, Fut>(&self, event: S, callback: F) -> EventHandler
+    pub fn on<F, Fut>(&self, event: InputEvent, handler: F)
     where
-        S: Into<String>,
-        T: 'static + Send + Sync + Clone,
-        F: FnMut(T) -> Fut + Send + 'static,
-        Fut: std::future::Future<Output = Result<(), Error>> + Send + 'static,
+        F: Fn(bool) -> Fut + Send + Sync + 'static,
+        Fut: std::future::Future<Output = crate::utils::Result<()>> + Send + 'static,
     {
-        self.events.on(event, callback)
+        self.events.on(event, handler);
     }
 }
 
@@ -411,7 +410,7 @@ mod tests {
                 pullup: false,
                 protocol: board.get_protocol(),
                 handler: Arc::new(RwLock::new(None)),
-                events: Default::default(),
+                events: EventManager::default(),
             },
             &board,
             13,
@@ -457,7 +456,7 @@ mod tests {
         // PRESSED
         let pressed_flag = Arc::new(AtomicBool::new(false));
         let moved_pressed_flag = pressed_flag.clone();
-        button.on(InputEvent::OnPress, move |_: ()| {
+        button.on(InputEvent::OnPress, move |_: bool| {
             let captured_flag = moved_pressed_flag.clone();
             async move {
                 captured_flag.store(true, Ordering::SeqCst);
@@ -468,7 +467,7 @@ mod tests {
         // RELEASED
         let released_flag = Arc::new(AtomicBool::new(false));
         let moved_released_flag = released_flag.clone();
-        button.on(InputEvent::OnRelease, move |_: ()| {
+        button.on(InputEvent::OnRelease, move |_: bool| {
             let captured_flag = moved_released_flag.clone();
             async move {
                 captured_flag.store(true, Ordering::SeqCst);
@@ -532,7 +531,7 @@ mod tests {
         // PRESSED
         let pressed_flag = Arc::new(AtomicBool::new(false));
         let moved_pressed_flag = pressed_flag.clone();
-        button.on(InputEvent::OnPress, move |_: ()| {
+        button.on(InputEvent::OnPress, move |_: bool| {
             let captured_flag = moved_pressed_flag.clone();
             async move {
                 captured_flag.store(true, Ordering::SeqCst);
@@ -543,7 +542,7 @@ mod tests {
         // RELEASED
         let released_flag = Arc::new(AtomicBool::new(false));
         let moved_released_flag = released_flag.clone();
-        button.on(InputEvent::OnRelease, move |_: ()| {
+        button.on(InputEvent::OnRelease, move |_: bool| {
             let captured_flag = moved_released_flag.clone();
             async move {
                 captured_flag.store(true, Ordering::SeqCst);
@@ -587,81 +586,6 @@ mod tests {
         button.detach();
         board.close();
     }
-
-    // #[hermes_five_macros::test]
-    // fn test_pullup_button_events() {
-    //     let board = Board::new(MockProtocol::default());
-    //     let button = Button::new_pullup(&board, 5).unwrap();
-    //
-    //     // CHANGE
-    //     let change_flag = Arc::new(AtomicBool::new(true));
-    //     let moved_change_flag = change_flag.clone();
-    //     button.on(InputEvent::OnChange, move |new_state: bool| {
-    //         let captured_flag = moved_change_flag.clone();
-    //         async move {
-    //             captured_flag.store(new_state, Ordering::SeqCst);
-    //             Ok(())
-    //         }
-    //     });
-    //
-    //     // PRESSED
-    //     let pressed_flag = Arc::new(AtomicBool::new(false));
-    //     let moved_pressed_flag = pressed_flag.clone();
-    //     button.on(InputEvent::OnPress, move |_: ()| {
-    //         let captured_flag = moved_pressed_flag.clone();
-    //         async move {
-    //             captured_flag.store(true, Ordering::SeqCst);
-    //             Ok(())
-    //         }
-    //     });
-    //
-    //     // RELEASED
-    //     let released_flag = Arc::new(AtomicBool::new(false));
-    //     let moved_released_flag = released_flag.clone();
-    //     button.on(InputEvent::OnRelease, move |_: ()| {
-    //         let captured_flag = moved_released_flag.clone();
-    //         async move {
-    //             captured_flag.store(true, Ordering::SeqCst);
-    //             Ok(())
-    //         }
-    //     });
-    //
-    //     assert!(change_flag.load(Ordering::SeqCst)); // true by default
-    //     assert!(!pressed_flag.load(Ordering::SeqCst));
-    //     assert!(!released_flag.load(Ordering::SeqCst));
-    //
-    //     // Simulate pin state change in the protocol => take value 0xFF
-    //     button
-    //         .protocol
-    //         .get_io()
-    //         .write()
-    //         .get_pin_mut(5)
-    //         .unwrap()
-    //         .value = 0;
-    //
-    //     pause!(500);
-    //
-    //     assert!(!change_flag.load(Ordering::SeqCst)); // changed to false
-    //     assert!(pressed_flag.load(Ordering::SeqCst));
-    //     assert!(!released_flag.load(Ordering::SeqCst));
-    //
-    //     // Simulate pin state change in the protocol => takes value 0
-    //     button
-    //         .protocol
-    //         .get_io()
-    //         .write()
-    //         .get_pin_mut(5)
-    //         .unwrap()
-    //         .value = 0xFF;
-    //
-    //     pause!(500);
-    //
-    //     assert!(change_flag.load(Ordering::SeqCst)); // change switched back to true
-    //     assert!(released_flag.load(Ordering::SeqCst));
-    //
-    //     button.detach();
-    //     board.close();
-    // }
 
     #[hermes_five_macros::test]
     fn test_button_display() {

--- a/hermes-five/src/devices/input/button.rs
+++ b/hermes-five/src/devices/input/button.rs
@@ -1,4 +1,5 @@
 use std::fmt::{Display, Formatter};
+use std::future::Future;
 use std::sync::Arc;
 
 use parking_lot::RwLock;
@@ -8,7 +9,7 @@ use crate::errors::Error;
 use crate::hardware::Hardware;
 use crate::io::{IoProtocol, PinIdOrName, PinModeId};
 use crate::pause;
-use crate::utils::{task, EventManager, State, TaskHandler};
+use crate::utils::{task, EventManager, GenericResult, State, TaskHandler};
 
 /// Represents a simple push button as an input of the board.
 /// <https://docs.arduino.cc/built-in-examples/digital/Button>
@@ -291,10 +292,11 @@ impl Button {
     ///     });
     /// }
     /// ```
-    pub fn on<F, Fut>(&self, event: InputEvent, handler: F)
+    pub fn on<F, Fut, R>(&self, event: InputEvent, handler: F)
     where
         F: Fn(bool) -> Fut + Send + Sync + 'static,
-        Fut: std::future::Future<Output = crate::utils::Result<()>> + Send + 'static,
+        Fut: Future<Output = R> + Send + 'static,
+        R: Into<GenericResult>
     {
         self.events.on(event, handler);
     }
@@ -449,7 +451,6 @@ mod tests {
             let captured_flag = moved_change_flag.clone();
             async move {
                 captured_flag.store(new_state, Ordering::SeqCst);
-                Ok(())
             }
         });
 
@@ -460,7 +461,6 @@ mod tests {
             let captured_flag = moved_pressed_flag.clone();
             async move {
                 captured_flag.store(true, Ordering::SeqCst);
-                Ok(())
             }
         });
 
@@ -471,7 +471,6 @@ mod tests {
             let captured_flag = moved_released_flag.clone();
             async move {
                 captured_flag.store(true, Ordering::SeqCst);
-                Ok(())
             }
         });
 
@@ -524,7 +523,6 @@ mod tests {
             let captured_flag = moved_change_flag.clone();
             async move {
                 captured_flag.store(new_state, Ordering::SeqCst);
-                Ok(())
             }
         });
 

--- a/hermes-five/src/devices/input/digital.rs
+++ b/hermes-five/src/devices/input/digital.rs
@@ -1,4 +1,5 @@
 use std::fmt::{Display, Formatter};
+use std::future::Future;
 use std::sync::Arc;
 
 use parking_lot::RwLock;
@@ -9,7 +10,7 @@ use crate::errors::Error;
 use crate::hardware::Hardware;
 use crate::io::{IoProtocol, PinIdOrName, PinModeId};
 use crate::pause;
-use crate::utils::{task, EventManager, State, TaskHandler};
+use crate::utils::{task, EventManager, GenericResult, State, TaskHandler};
 
 /// Represents a digital sensor of unspecified type: an [`Input`] [`Device`] that reads digital values
 /// from an INPUT compatible pin.
@@ -149,7 +150,6 @@ impl DigitalInput {
     ///         // Triggered function when the sensor state changes.
     ///         sensor.on(InputEvent::OnChange, |value: bool| async move {
     ///             println!("Sensor value changed: {}", value);
-    ///             Ok(())
     ///         });
     ///
     ///         // The above code will run forever.
@@ -165,10 +165,11 @@ impl DigitalInput {
     ///     });
     /// }
     /// ```
-    pub fn on<F, Fut>(&self, event: InputEvent, handler: F)
+    pub fn on<F, Fut, R>(&self, event: InputEvent, handler: F)
     where
         F: Fn(bool) -> Fut + Send + Sync + 'static,
-        Fut: std::future::Future<Output = crate::utils::Result<()>> + Send + 'static,
+        Fut: Future<Output = R> + Send + 'static,
+        R: Into<GenericResult>
     {
         self.events.on(event, handler);
     }
@@ -248,7 +249,6 @@ mod tests {
             let captured_flag = moved_change_flag.clone();
             async move {
                 captured_flag.store(new_state, Ordering::SeqCst);
-                Ok(())
             }
         });
 
@@ -259,7 +259,6 @@ mod tests {
             let captured_flag = moved_high_flag.clone();
             async move {
                 captured_flag.store(true, Ordering::SeqCst);
-                Ok(())
             }
         });
 
@@ -270,7 +269,6 @@ mod tests {
             let captured_flag = moved_low_flag.clone();
             async move {
                 captured_flag.store(true, Ordering::SeqCst);
-                Ok(())
             }
         });
 

--- a/hermes-five/src/devices/input/digital.rs
+++ b/hermes-five/src/devices/input/digital.rs
@@ -9,7 +9,7 @@ use crate::errors::Error;
 use crate::hardware::Hardware;
 use crate::io::{IoProtocol, PinIdOrName, PinModeId};
 use crate::pause;
-use crate::utils::{task, EventHandler, EventManager, State, TaskHandler};
+use crate::utils::{task, EventManager, State, TaskHandler};
 
 /// Represents a digital sensor of unspecified type: an [`Input`] [`Device`] that reads digital values
 /// from an INPUT compatible pin.
@@ -34,7 +34,7 @@ pub struct DigitalInput {
     handler: Arc<RwLock<Option<TaskHandler>>>,
     /// The event manager for the DigitalInput.
     #[cfg_attr(feature = "serde", serde(skip))]
-    events: EventManager,
+    events: EventManager<InputEvent, bool>,
 }
 
 impl DigitalInput {
@@ -51,7 +51,7 @@ impl DigitalInput {
             state: Arc::new(RwLock::new(pin.value != 0)),
             protocol: board.get_protocol(),
             handler: Arc::new(RwLock::new(None)),
-            events: Default::default(),
+            events: EventManager::default(),
         };
 
         // Set pin mode to INPUT.
@@ -98,8 +98,8 @@ impl DigitalInput {
                             *self_clone.state.write() = pin_value;
                             self_clone.events.emit(InputEvent::OnChange, pin_value);
                             match pin_value {
-                                true => self_clone.events.emit(InputEvent::OnHigh, ()),
-                                false => self_clone.events.emit(InputEvent::OnLow, ()),
+                                true => self_clone.events.emit(InputEvent::OnHigh, pin_value),
+                                false => self_clone.events.emit(InputEvent::OnLow, pin_value),
                             }
                         }
 
@@ -165,14 +165,12 @@ impl DigitalInput {
     ///     });
     /// }
     /// ```
-    pub fn on<S, F, T, Fut>(&self, event: S, callback: F) -> EventHandler
+    pub fn on<F, Fut>(&self, event: InputEvent, handler: F)
     where
-        S: Into<String>,
-        T: 'static + Send + Sync + Clone,
-        F: FnMut(T) -> Fut + Send + 'static,
-        Fut: std::future::Future<Output = Result<(), Error>> + Send + 'static,
+        F: Fn(bool) -> Fut + Send + Sync + 'static,
+        Fut: std::future::Future<Output = crate::utils::Result<()>> + Send + 'static,
     {
-        self.events.on(event, callback)
+        self.events.on(event, handler);
     }
 }
 
@@ -257,7 +255,7 @@ mod tests {
         // HIGH
         let high_flag = Arc::new(AtomicBool::new(false));
         let moved_high_flag = high_flag.clone();
-        button.on(InputEvent::OnHigh, move |_: ()| {
+        button.on(InputEvent::OnHigh, move |_: bool| {
             let captured_flag = moved_high_flag.clone();
             async move {
                 captured_flag.store(true, Ordering::SeqCst);
@@ -268,7 +266,7 @@ mod tests {
         // LOW
         let low_flag = Arc::new(AtomicBool::new(false));
         let moved_low_flag = low_flag.clone();
-        button.on(InputEvent::OnLow, move |_: ()| {
+        button.on(InputEvent::OnLow, move |_: bool| {
             let captured_flag = moved_low_flag.clone();
             async move {
                 captured_flag.store(true, Ordering::SeqCst);

--- a/hermes-five/src/devices/input/mod.rs
+++ b/hermes-five/src/devices/input/mod.rs
@@ -16,7 +16,8 @@ pub trait Input: Device {
 }
 dyn_clone::clone_trait_object!(Input);
 
-/// Lists all events a Input type device can emit/listen.
+/// Lists all events an Input type device can emit/listen.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum InputEvent {
     /// Triggered when the Input value changes.
     OnChange,

--- a/hermes-five/src/hardware/board.rs
+++ b/hermes-five/src/hardware/board.rs
@@ -2,13 +2,13 @@ use crate::errors::Error;
 use crate::hardware::Hardware;
 use crate::io::{IoData, IoTransport, RemoteIo, IO};
 use crate::io::{IoProtocol, PinModeId};
-use crate::utils::{task, Range};
-use crate::utils::{EventHandler, EventManager};
+use crate::utils::{task, EventManager, Range};
 use parking_lot::RwLock;
 use std::fmt::Display;
 use std::sync::Arc;
 
 /// Lists all events a Board can emit/listen.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum BoardEvent {
     /// Triggered when the board connexion is established and the handshake has been made.
     OnReady,
@@ -30,11 +30,11 @@ impl From<BoardEvent> for String {
 /// Represents a physical board (Arduino most-likely) where your [`Device`] can be attached and controlled through this API.
 /// The board gives access to [`IoData`] through a communication [`IoProtocol`].
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug)]
 pub struct Board {
     /// The event manager for the board.
     #[cfg_attr(feature = "serde", serde(skip))]
-    events: EventManager,
+    events: EventManager<BoardEvent, Board>,
     /// The inner protocol used by this Board.
     protocol: Box<dyn IoProtocol>,
 }
@@ -82,7 +82,7 @@ impl Default for Board {
 impl<T: IoTransport> From<T> for Board {
     fn from(transport: T) -> Self {
         Self {
-            events: Default::default(),
+            events: EventManager::default(),
             protocol: Box::new(RemoteIo::from(transport)),
         }
     }
@@ -144,7 +144,8 @@ impl Board {
     ///
     /// #[hermes_five::runtime]
     /// async fn main() {
-    ///     let board = Board::run();
+    ///
+    /// let board = Board::run();
     ///     // Is equivalent to:
     ///     let mut board = Board::default().open();
     ///
@@ -157,12 +158,11 @@ impl Board {
     /// }
     /// ```
     pub fn open(self) -> Self {
-        let events_clone = self.events.clone();
         let callback_board = self.clone();
 
         task::run(async move {
             let board = callback_board.blocking_open()?;
-            events_clone.emit(BoardEvent::OnReady, board);
+            board.events.emit(BoardEvent::OnReady, board.clone());
             Ok(())
         })
         .expect("Task failed");
@@ -198,11 +198,10 @@ impl Board {
     /// }
     /// ```
     pub fn close(self) -> Self {
-        let events = self.events.clone();
         let callback_board = self.clone();
         task::run(async move {
             let board = callback_board.blocking_close()?;
-            events.emit(BoardEvent::OnClose, board);
+            board.events.emit(BoardEvent::OnClose, board.clone());
             Ok(())
         })
         .expect("Task failed");
@@ -231,9 +230,9 @@ impl Board {
     /// Registers a callback to be executed on a given event.
     ///
     /// Available events for a board are defined by the enum: [`BoardEvent`]:
-    /// - **`OnRead` | `ready`:** Triggered when the board is connected and ready to run.    
+    /// - **`OnRead` | `ready`:** Triggered when the board is connected and ready to run.
     ///    _The callback must receive the following parameter: `|_: Board| { ... }`_
-    /// - **`OnClose` | `close`:** Triggered when the board is disconnected.        
+    /// - **`OnClose` | `close`:** Triggered when the board is disconnected.
     ///    _The callback must receive the following parameter: `|_: Board| { ... }`_
     ///
     /// # Example
@@ -250,14 +249,12 @@ impl Board {
     ///     });
     /// }
     /// ```
-    pub fn on<S, F, T, Fut>(&self, event: S, callback: F) -> EventHandler
+    pub fn on<F, Fut>(&self, event: BoardEvent, handler: F)
     where
-        S: Into<String>,
-        T: 'static + Send + Sync + Clone,
-        F: FnMut(T) -> Fut + Send + 'static,
-        Fut: std::future::Future<Output = Result<(), Error>> + Send + 'static,
+        F: Fn(Board) -> Fut + Send + Sync + 'static,
+        Fut: std::future::Future<Output = crate::utils::Result<()>> + Send + 'static,
     {
-        self.events.on(event, callback)
+        self.events.on(event, handler);
     }
 }
 

--- a/hermes-five/src/hardware/board.rs
+++ b/hermes-five/src/hardware/board.rs
@@ -2,9 +2,10 @@ use crate::errors::Error;
 use crate::hardware::Hardware;
 use crate::io::{IoData, IoTransport, RemoteIo, IO};
 use crate::io::{IoProtocol, PinModeId};
-use crate::utils::{task, EventManager, Range};
+use crate::utils::{task, EventManager, GenericResult, Range};
 use parking_lot::RwLock;
 use std::fmt::Display;
+use std::future::Future;
 use std::sync::Arc;
 
 /// Lists all events a Board can emit/listen.
@@ -152,7 +153,6 @@ impl Board {
     ///     // Register something to do when the board is connected.
     ///     board.on(BoardEvent::OnReady, |_: Board| async move {
     ///         // Something to do when connected.
-    ///         Ok(())
     ///     });
     ///     // code here will be executed right away, before the board is actually connected.
     /// }
@@ -189,11 +189,9 @@ impl Board {
     ///         // Something to do when connected.
     ///         pause!(3000);
     ///         board.close();
-    ///         Ok(())
     ///     });
     ///     board.on(BoardEvent::OnClose, |_: Board| async move {
     ///         // Something to do when connection closes.
-    ///         Ok(())
     ///     });
     /// }
     /// ```
@@ -245,14 +243,14 @@ impl Board {
     ///     let board = Board::run();
     ///     board.on(BoardEvent::OnReady, |_: Board| async move {
     ///         // Here, you know the board to be connected and ready to receive data.
-    ///         Ok(())
     ///     });
     /// }
     /// ```
-    pub fn on<F, Fut>(&self, event: BoardEvent, handler: F)
+    pub fn on<F, Fut, R>(&self, event: BoardEvent, handler: F)
     where
         F: Fn(Board) -> Fut + Send + Sync + 'static,
-        Fut: std::future::Future<Output = crate::utils::Result<()>> + Send + 'static,
+        Fut: Future<Output = R> + Send + 'static,
+        R: Into<GenericResult>
     {
         self.events.on(event, handler);
     }
@@ -286,7 +284,6 @@ impl IO for Board {
     ///     board.on(BoardEvent::OnReady, |mut board: Board| async move {
     ///         println!("Board connected: {}", board);
     ///         println!("Pins {:#?}", board.get_io().read().pins);
-    ///         Ok(())
     ///     });
     /// }
     fn get_io(&self) -> &Arc<RwLock<IoData>> {
@@ -405,7 +402,6 @@ mod tests {
             async move {
                 captured_flag.store(true, Ordering::SeqCst);
                 assert!(board.is_connected());
-                Ok(())
             }
         });
         pause!(500);
@@ -444,7 +440,6 @@ mod tests {
             async move {
                 captured_flag.store(true, Ordering::SeqCst);
                 assert!(!board.is_connected());
-                Ok(())
             }
         });
 

--- a/hermes-five/src/io/transports/wifi.rs
+++ b/hermes-five/src/io/transports/wifi.rs
@@ -4,8 +4,9 @@ use crate::io::IoTransport;
 use parking_lot::Mutex;
 use std::fmt::{Debug, Display, Formatter};
 use std::io::{Read, Write};
-use std::net::TcpStream;
+use std::net::{TcpStream, ToSocketAddrs};
 use std::sync::Arc;
+use std::time::Duration;
 
 /// Represents an [`IoTransport`] layer based on a WiFi connection.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -65,9 +66,16 @@ impl Display for WiFi {
 #[cfg_attr(feature = "serde", typetag::serde)]
 impl IoTransport for WiFi {
     fn open(&mut self) -> Result<(), Error> {
-        let stream = TcpStream::connect(self.address.clone())?;
 
-        // Save the IO (required by handshake).
+        // Resolve to SocketAddr
+        let addr = self.address
+            .to_socket_addrs()?
+            .next()
+            .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::Other, "Invalid address"))?;
+
+        let stream = TcpStream::connect_timeout(&addr, Duration::from_secs(10))?;
+
+        // Save the IO (required by handshake). 
         self.stream = Arc::new(Mutex::new(Some(stream)));
 
         Ok(())

--- a/hermes-five/src/utils/events.rs
+++ b/hermes-five/src/utils/events.rs
@@ -1,34 +1,37 @@
 //! Defines Hermes-Five event manager system.
 
-use std::any::Any;
+use parking_lot::RwLock;
 use std::collections::HashMap;
 use std::fmt::{Debug, Formatter};
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
-
-use futures::future::BoxFuture;
-use futures::FutureExt;
-use parking_lot::Mutex;
-
+use std::sync::atomic::{AtomicUsize, Ordering};
 use crate::errors::Error;
 use crate::utils::task;
 
-type Callback =
-    dyn FnMut(Arc<dyn Any + Send + Sync>) -> BoxFuture<'static, Result<(), Error>> + Send;
-pub type EventHandler = usize;
-struct CallbackWrapper {
-    id: EventHandler,
-    callback: Box<Callback>,
-}
-type SyncedCallbackMap = Mutex<HashMap<String, Vec<CallbackWrapper>>>;
+pub type Result<T> = std::result::Result<T, Error>;
+pub type BoxedCallback<T> =
+Box<dyn Fn(T) -> Pin<Box<dyn Future<Output = Result<()>> + Send>> + Send + Sync>;
 
-#[derive(Clone, Default)]
-pub struct EventManager {
-    callbacks: Arc<SyncedCallbackMap>,
+
+pub type EventHandler = usize;
+struct CallbackWrapper<T> {
+    id: EventHandler,
+    callback: BoxedCallback<T>,
+}
+
+#[derive(Clone)]
+pub struct EventManager<Ev, T> {
+    callbacks: Arc<RwLock<HashMap<Ev, Vec<CallbackWrapper<T>>>>>,
     next_id: Arc<AtomicUsize>,
 }
 
-impl EventManager {
+impl<Ev, T> EventManager<Ev, T>
+where
+    Ev: Eq + std::hash::Hash + Copy + Send + Sync + 'static,
+    T: Clone {
+
     /// Register event handler for a specific event name.
     ///
     /// # Parameters
@@ -54,55 +57,35 @@ impl EventManager {
     /// #[hermes_five::runtime]
     /// async fn main() {
     ///     // Instantiate an EventManager
-    ///     let events: EventManager = Default::default();
+    ///     let events: EventManager<&str, &str> = Default::default();
     ///
     ///     // Register various handlers for the same event.
-    ///     events.on("ready", |name: String| async move { Ok(()) });
-    ///     events.on("ready", |age: u8| async move { Ok(()) });
-    ///     events.on("ready", |whatever: Vec<[u8;4]>| async move { Ok(()) });
-    ///     events.on("ready", |(name, age): (&str, u8)| async move {
-    ///         println!("Event handler with parameters: {} {}.", name, age);
-    ///         pause!(1000);
-    ///         println!("Event handler done");
-    ///         Ok(())
-    ///     });
+    ///     events.on("ready", |data: &str| async move { println!("Callback 1"); Ok(()) });
+    ///     events.on("ready", |data: &str| async move { println!("Callback 2"); Ok(()) });
     ///
     ///     // Invoke handlers for "ready" event.
-    ///     events.emit("ready", ("foo", 69u8));
-    ///
-    ///     // None matching handler (because of parameters) will never be called.
-    ///     events.emit("ready", ("bar"));
+    ///     events.emit("ready", "I am ready!");
     /// }
     /// ```
-    pub fn on<S, F, T, Fut>(&self, event: S, mut callback: F) -> EventHandler
+    pub fn on<F, Fut>(&self, event: Ev, handler: F) -> EventHandler
     where
-        S: Into<String>,
-        T: 'static + Send + Sync + Clone,
-        F: FnMut(T) -> Fut + Send + 'static,
-        Fut: std::future::Future<Output = Result<(), Error>> + Send + 'static,
+        F: Fn(T) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<()>> + Send + 'static,
     {
-        let event_name = event.into();
+
         // Generate a unique ID.
         let id = self.next_id.fetch_add(1, Ordering::Relaxed);
-        // Boxes the callback and downcast its parameter.
-        let boxed_callback =
-            Box::new(
-                move |arg: Arc<dyn Any + Send + Sync>| match arg.downcast::<T>() {
-                    Ok(arg) => callback((*arg).clone()).boxed(),
-                    Err(_) => Box::pin(async { Ok(()) }),
-                },
-            );
+        // Boxes the callback
+        let boxed_callback: BoxedCallback<T> = Box::new(move |arg: T| Box::pin(handler(arg)));
 
+        // Creates the callback unique wrapper
         let wrapper = CallbackWrapper {
             id,
             callback: boxed_callback,
         };
 
-        self.callbacks
-            .lock()
-            .entry(event_name)
-            .or_default()
-            .push(wrapper);
+        let mut lock = self.callbacks.write();
+        lock.entry(event).or_default().push(wrapper);
 
         id
     }
@@ -125,38 +108,31 @@ impl EventManager {
     /// #[hermes_five::runtime]
     /// async fn main() {
     ///     // Instantiate an EventManager
-    ///     let events: EventManager = Default::default();
+    ///     let events: EventManager<&str, &str> = Default::default();
     ///
     ///     // Register various handlers for the same event.
-    ///     events.on("ready", |name: &str| async move {
+    ///     events.on("ready", |data: &str| async move {
     ///         println!("Callback 1");
     ///         Ok(())
     ///     });
-    ///     events.on("ready", |age: u8| async move {
+    ///     events.on("ready", |data: &str| async move {
     ///         println!("Callback 2");
     ///         Ok(())
     ///     });
     ///
     ///     // Invoke handlers for "ready" event matching &str parameter.
     ///     events.emit("ready", "foo");
-    ///     // Invoke handlers for "ready" event matching u8 parameter.
-    ///     events.emit("ready", 42);
-    ///
-    ///     // No event registered for "nothing" event.
-    ///     events.emit("nothing", ());
     /// }
     /// ```
-    pub fn emit<S, T>(&self, event: S, payload: T)
+    pub fn emit(&self, event: Ev, arg: T)
     where
-        S: Into<String>,
-        T: 'static + Send + Sync,
+        Self: Sized + Send + Sync + 'static,
     {
-        let payload_any: Arc<dyn Any + Send + Sync> = Arc::new(payload);
-        if let Some(callbacks) = self.callbacks.lock().get_mut(&event.into()) {
-            for wrapper in callbacks.iter_mut() {
-                let payload_clone = payload_any.clone();
-                let future = (wrapper.callback)(payload_clone);
-                let _ = task::run(future);
+        if let Some(wrappers) =  self.callbacks.read().get(&event) {
+            for wrapper in wrappers {
+                let callback = &wrapper.callback;
+                let arg_copy = arg.clone();
+                let _ = task::run(callback(arg_copy));
             }
         }
     }
@@ -171,7 +147,7 @@ impl EventManager {
     /// #[hermes_five::runtime]
     /// async fn main() {
     ///     // Instantiate an EventManager
-    ///     let events: EventManager = Default::default();
+    ///     let events: EventManager<&str, u8> = Default::default();
     ///
     ///     // Register various handlers for the same event.
     ///     let handler1 = events.on("ready", |age: u8| async move {
@@ -194,15 +170,24 @@ impl EventManager {
     pub fn unregister(&self, handler: EventHandler) {
         let _ = &self
             .callbacks
-            .lock()
+            .write()
             .values_mut()
             .for_each(|v| v.retain(|cb| cb.id != handler));
     }
 }
 
-impl Debug for EventManager {
+impl<Ev, T> Default for EventManager<Ev, T> {
+    fn default() -> Self {
+        Self {
+            callbacks: Arc::new(RwLock::new(HashMap::new())),
+            next_id: Arc::new(Default::default()),
+        }
+    }
+}
+
+impl<Ev, T> Debug for EventManager<Ev, T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self.callbacks.lock().len() {
+        match self.callbacks.read().len() {
             1 => write!(f, "EventManager: 1 registered callback"),
             count => write!(f, "EventManager: {} registered callbacks", count),
         }
@@ -219,7 +204,7 @@ mod tests {
 
     #[hermes_five_macros::test]
     async fn test_register_and_emit_event() {
-        let events: EventManager = Default::default();
+        let events: EventManager<&str, Arc<AtomicBool>> = Default::default();
         let payload = Arc::new(AtomicBool::new(false));
 
         events.on("register", |flag: Arc<AtomicBool>| async move {
@@ -238,7 +223,7 @@ mod tests {
 
     #[hermes_five_macros::test]
     async fn test_unregister_event_handler() {
-        let events: EventManager = Default::default();
+        let events: EventManager<&str, Arc<AtomicBool>> = Default::default();
         let flag = Arc::new(AtomicBool::new(false));
 
         let handler = events.on("unregister", |flag: Arc<AtomicBool>| async move {
@@ -258,29 +243,17 @@ mod tests {
 
     #[hermes_five_macros::test]
     async fn test_multiple_handlers() {
-        let events: EventManager = Default::default();
+        let events: EventManager<&str, Arc<AtomicUsize>> = Default::default();
         let flag = Arc::new(AtomicUsize::new(0));
 
-        events.on("multiple", |flag: Arc<AtomicUsize>| async move {
+        let callback = |flag: Arc<AtomicUsize>| async move {
             let value = flag.load(Ordering::SeqCst);
             flag.store(value + 1, Ordering::SeqCst);
             Ok(())
-        });
+        };
 
-        events.on("multiple", |flag: Arc<AtomicUsize>| async move {
-            let value = flag.load(Ordering::SeqCst);
-            flag.store(value + 1, Ordering::SeqCst);
-            Ok(())
-        });
-
-        events.on(
-            "multiple",
-            |(_not_matching, flag): (u8, Arc<AtomicUsize>)| async move {
-                let value = flag.load(Ordering::SeqCst);
-                flag.store(value + 1, Ordering::SeqCst);
-                Ok(())
-            },
-        );
+        events.on("multiple", callback);
+        events.on("multiple", callback);
 
         events.emit("multiple", flag.clone());
 
@@ -294,7 +267,7 @@ mod tests {
 
     #[hermes_five_macros::test]
     async fn test_event_with_complex_payload() {
-        let events: EventManager = Default::default();
+        let events: EventManager<&str, (u8,u8,Arc<AtomicU8>)> = Default::default();
         let flag = Arc::new(AtomicU8::new(0));
 
         events.on(
@@ -316,14 +289,14 @@ mod tests {
 
     #[hermes_five_macros::test]
     async fn test_no_handlers_for_event() {
-        let events: EventManager = Default::default();
+        let events: EventManager<&str, ()> = Default::default();
         let result = events.emit("no_event", ());
         assert_eq!(result, (), "Nothing to do.");
     }
 
     #[test]
     fn test_event_manager_debug() {
-        let events: EventManager = Default::default();
+        let events: EventManager<&str, ()> = Default::default();
         events.on("test", |_: ()| async move { Ok(()) });
         assert_eq!(
             format!("{:?}", events),

--- a/hermes-five/src/utils/events.rs
+++ b/hermes-five/src/utils/events.rs
@@ -1,19 +1,16 @@
 //! Defines Hermes-Five event manager system.
 
+use crate::utils::{task, GenericResult};
 use parking_lot::RwLock;
 use std::collections::HashMap;
 use std::fmt::{Debug, Formatter};
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use crate::errors::Error;
-use crate::utils::task;
+use std::sync::Arc;
 
-pub type Result<T> = std::result::Result<T, Error>;
 pub type BoxedCallback<T> =
-Box<dyn Fn(T) -> Pin<Box<dyn Future<Output = Result<()>> + Send>> + Send + Sync>;
-
+    Box<dyn Fn(T) -> Pin<Box<dyn Future<Output = GenericResult> + Send>> + Send + Sync>;
 
 pub type EventHandler = usize;
 struct CallbackWrapper<T> {
@@ -30,8 +27,8 @@ pub struct EventManager<Ev, T> {
 impl<Ev, T> EventManager<Ev, T>
 where
     Ev: Eq + std::hash::Hash + Copy + Send + Sync + 'static,
-    T: Clone {
-
+    T: Clone,
+{
     /// Register event handler for a specific event name.
     ///
     /// # Parameters
@@ -60,23 +57,29 @@ where
     ///     let events: EventManager<&str, &str> = Default::default();
     ///
     ///     // Register various handlers for the same event.
-    ///     events.on("ready", |data: &str| async move { println!("Callback 1"); Ok(()) });
-    ///     events.on("ready", |data: &str| async move { println!("Callback 2"); Ok(()) });
+    ///     events.on("ready", |data: &str| async move { println!("Callback 1"); });
+    ///     events.on("ready", |data: &str| async move { println!("Callback 2"); });
     ///
     ///     // Invoke handlers for "ready" event.
     ///     events.emit("ready", "I am ready!");
     /// }
     /// ```
-    pub fn on<F, Fut>(&self, event: Ev, handler: F) -> EventHandler
+    pub fn on<F, Fut, R>(&self, event: Ev, handler: F) -> EventHandler
     where
         F: Fn(T) -> Fut + Send + Sync + 'static,
-        Fut: Future<Output = Result<()>> + Send + 'static,
+        Fut: Future<Output = R> + Send + 'static,
+        R: Into<GenericResult>,
     {
-
         // Generate a unique ID.
         let id = self.next_id.fetch_add(1, Ordering::Relaxed);
         // Boxes the callback
-        let boxed_callback: BoxedCallback<T> = Box::new(move |arg: T| Box::pin(handler(arg)));
+        let boxed_callback: BoxedCallback<T> = Box::new(move |arg: T| {
+            let fut = handler(arg);
+            Box::pin(async move {
+                let r = fut.await;
+                r.into()
+            })
+        });
 
         // Creates the callback unique wrapper
         let wrapper = CallbackWrapper {
@@ -113,11 +116,9 @@ where
     ///     // Register various handlers for the same event.
     ///     events.on("ready", |data: &str| async move {
     ///         println!("Callback 1");
-    ///         Ok(())
     ///     });
     ///     events.on("ready", |data: &str| async move {
     ///         println!("Callback 2");
-    ///         Ok(())
     ///     });
     ///
     ///     // Invoke handlers for "ready" event matching &str parameter.
@@ -128,7 +129,7 @@ where
     where
         Self: Sized + Send + Sync + 'static,
     {
-        if let Some(wrappers) =  self.callbacks.read().get(&event) {
+        if let Some(wrappers) = self.callbacks.read().get(&event) {
             for wrapper in wrappers {
                 let callback = &wrapper.callback;
                 let arg_copy = arg.clone();
@@ -152,11 +153,9 @@ where
     ///     // Register various handlers for the same event.
     ///     let handler1 = events.on("ready", |age: u8| async move {
     ///         println!("Callback 1");
-    ///         Ok(())
     ///     });
     ///     let handler2 = events.on("ready", |age: u8| async move {
     ///         println!("Callback 2");
-    ///         Ok(())
     ///     });
     ///
     ///     // Unregister handler 1.
@@ -209,7 +208,6 @@ mod tests {
 
         events.on("register", |flag: Arc<AtomicBool>| async move {
             flag.store(true, Ordering::SeqCst);
-            Ok(())
         });
 
         events.emit("register", payload.clone());
@@ -228,7 +226,6 @@ mod tests {
 
         let handler = events.on("unregister", |flag: Arc<AtomicBool>| async move {
             flag.store(true, Ordering::SeqCst);
-            Ok(())
         });
 
         events.unregister(handler);
@@ -249,7 +246,6 @@ mod tests {
         let callback = |flag: Arc<AtomicUsize>| async move {
             let value = flag.load(Ordering::SeqCst);
             flag.store(value + 1, Ordering::SeqCst);
-            Ok(())
         };
 
         events.on("multiple", callback);
@@ -267,14 +263,13 @@ mod tests {
 
     #[hermes_five_macros::test]
     async fn test_event_with_complex_payload() {
-        let events: EventManager<&str, (u8,u8,Arc<AtomicU8>)> = Default::default();
+        let events: EventManager<&str, (u8, u8, Arc<AtomicU8>)> = Default::default();
         let flag = Arc::new(AtomicU8::new(0));
 
         events.on(
             "payload",
             |(number1, number2, container): (u8, u8, Arc<AtomicU8>)| async move {
                 container.store(number1 + number2, Ordering::SeqCst);
-                Ok(())
             },
         );
         events.emit("payload", (42u8, 69u8, flag.clone()));
@@ -297,12 +292,12 @@ mod tests {
     #[test]
     fn test_event_manager_debug() {
         let events: EventManager<&str, ()> = Default::default();
-        events.on("test", |_: ()| async move { Ok(()) });
+        events.on("test", |_: ()| async move { });
         assert_eq!(
             format!("{:?}", events),
             "EventManager: 1 registered callback"
         );
-        events.on("test2", |_: ()| async move { Ok(()) });
+        events.on("test2", |_: ()| async move { });
         assert_eq!(
             format!("{:?}", events),
             "EventManager: 2 registered callbacks"

--- a/hermes-five/src/utils/mod.rs
+++ b/hermes-five/src/utils/mod.rs
@@ -1,5 +1,6 @@
 //! Various utilities and helper functions.
 
+use crate::errors::Error;
 pub use log;
 #[cfg(test)]
 pub use serial_test;
@@ -17,6 +18,30 @@ pub use crate::utils::range::*;
 pub use crate::utils::scale::*;
 pub use crate::utils::state::*;
 pub use crate::utils::task::*;
+
+/// Represents the result of an event callback or a task.
+///
+/// An event callback or a task may return either () or Result<(), Error> for flexibility which
+/// will be converted to EventResult sent to the runtime.
+pub enum GenericResult {
+    Ok,
+    Err(Error),
+}
+
+impl From<Result<(), Error>> for GenericResult {
+    fn from(result: Result<(), Error>) -> Self {
+        match result {
+            Ok(_) => GenericResult::Ok,
+            Err(e) => GenericResult::Err(e),
+        }
+    }
+}
+
+impl From<()> for GenericResult {
+    fn from(_: ()) -> Self {
+        GenericResult::Ok
+    }
+}
 
 /// Helper to format a buffer as hex.
 #[allow(dead_code)]

--- a/hermes-five/src/utils/task.rs
+++ b/hermes-five/src/utils/task.rs
@@ -63,7 +63,7 @@ struct TaskRegistration {
 impl TaskRegistration {
     /// Get a handle to the current task context.
     fn get() -> Result<Self, Error> {
-        TASK.try_with(|t| t.clone()).map_err(|_| RuntimeError)
+        TASK.try_with(|t| t.clone()).map_err(|e| InternalError {info: e.to_string()})
     }
 
     /// Runs a future within the current task context.
@@ -100,7 +100,7 @@ impl TaskRegistration {
 
         // send error, if there was one.
         if let TaskResult::Err(e) = res {
-            queue.results.send(e).map_err(|_| RuntimeError)?;
+            queue.results.send(e).map_err(|e| InternalError {info: e.to_string()})?;
         }
 
         Ok(())

--- a/hermes-five/src/utils/task.rs
+++ b/hermes-five/src/utils/task.rs
@@ -8,32 +8,10 @@ use tokio::task::JoinHandle;
 use tokio::{task, task_local};
 
 use crate::errors::{Error, RuntimeError, InternalError};
-
-/// Represents the result of a TaskResult.
-/// A task may return either () or Result<(), Error> for flexibility which
-/// will be converted to TaskResult sent to the runtime.
-pub enum TaskResult {
-    Ok,
-    Err(Error),
-}
+use crate::utils::GenericResult;
 
 /// Represents an arc protected handler for a task.
 pub type TaskHandler = JoinHandle<Result<(), Error>>;
-
-impl From<Result<(), Error>> for TaskResult {
-    fn from(result: Result<(), Error>) -> Self {
-        match result {
-            Ok(_) => TaskResult::Ok,
-            Err(e) => TaskResult::Err(e),
-        }
-    }
-}
-
-impl From<()> for TaskResult {
-    fn from(_: ()) -> Self {
-        TaskResult::Ok
-    }
-}
 
 pub fn setup_rt(test: bool) -> Runtime {
     let mut builder = if test {
@@ -70,7 +48,7 @@ impl TaskRegistration {
     async fn catch_errors<F, T>(self, future: F) -> Result<(), Error>
     where
         F: Future<Output = T> + Send + 'static,
-        T: Into<TaskResult> + Send + 'static,
+        T: Into<GenericResult> + Send + 'static,
     {
         // allow ourselves to catch panics
         let future = AssertUnwindSafe(future).catch_unwind();
@@ -85,7 +63,7 @@ impl TaskRegistration {
         let queue = task.take_value().ok_or(RuntimeError)?;
 
         // check for a panic.
-        let res: TaskResult = match res {
+        let res: GenericResult = match res {
             Ok(res) => res.into(),
             Err(panic) => {
                 // ignore errors if receiver is missing.
@@ -99,7 +77,7 @@ impl TaskRegistration {
         };
 
         // send error, if there was one.
-        if let TaskResult::Err(e) = res {
+        if let GenericResult::Err(e) = res {
             queue.results.send(e).map_err(|e| InternalError {info: e.to_string()})?;
         }
 
@@ -163,7 +141,7 @@ impl Runtime {
 pub fn run<F, T>(future: F) -> Result<TaskHandler, Error>
 where
     F: Future<Output = T> + Send + 'static,
-    T: Into<TaskResult> + Send + 'static,
+    T: Into<GenericResult> + Send + 'static,
 {
     let task = TaskRegistration::get()?;
 


### PR DESCRIPTION
Fixes both  #8  and #17 .

**API Changes:**
Events are now strongly typed. It means callback cannot be registered with unmatching events.
A new limitation as been introduced: all callbacks of a given event manager must have the same argument type.
